### PR TITLE
Updated api/v3.py for APIv3 resource name changes

### DIFF
--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -116,8 +116,8 @@ class API(BaseAPI):
                 resource['type'],
                 resource['tags'],
                 resource['exported'],
-                resource['sourcefile'],
-                resource['sourceline'],
+                resource['file'],
+                resource['line'],
                 resource['parameters'],
                 )
 


### PR DESCRIPTION
PuppetDB APIv3 from APIv2 has 2 keys within the resource
endpoint have been changed.
'sourcefile' has been changed to 'file'
'sourceline' has been changed to 'line'

This patch allows pypuppetdb to read resources from APIv3.

ref:
http://docs.puppetlabs.com/puppetdb/1.5/api/query/v3/resources.html#response-f\
ormat
