### PR TITLE
Basic integration of new v3 API endpoints and query paging

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -37,9 +37,9 @@ ENDPOINTS = {
         'mbean': 'metrics/mbean',
         'reports': 'reports',
         'events': 'events',
-	'event-counts': 'event-counts',
-	'aggregate-event-counts': 'aggregate-event-counts',
-	'server-time': 'server-time',
+        'event-counts': 'event-counts',
+        'aggregate-event-counts': 'aggregate-event-counts',
+        'server-time': 'server-time',
     },
 }
 
@@ -138,7 +138,7 @@ class BaseAPI(object):
     def total(self):
         """The total-count of the last request to PuppetDB
         if enabled as parameter in _query method
-        
+
         :returns Number of total results
         :rtype :obj:`int`
         """
@@ -184,7 +184,9 @@ class BaseAPI(object):
 
         return url
 
-    def _query(self, endpoint, path=None, query=None, order_by=None, limit=None, offset=None, include_total=None, summarize_by=None, count_by=None, count_filter=None):
+    def _query(self, endpoint, path=None, query=None,
+               order_by=None, limit=None, offset=None, include_total=None,
+               summarize_by=None, count_by=None, count_filter=None):
         """This method actually querries PuppetDB. Provided an endpoint and an
         optional path and/or query it will fire a request at PuppetDB. If
         PuppetDB can be reached and answers within the timeout we'll decode
@@ -225,8 +227,9 @@ class BaseAPI(object):
         """
         log.debug('_query called with endpoint: {0}, path: {1}, query: {2}, '
                   'limit: {3}, offset: {4}, summarize_by {5}, count_by {6}, '
-		  'count_filter: {7}'.format(endpoint, path, query, limit, 
-			  offset, summarize_by, count_by, count_filter))
+                  'count_filter: {7}'.format(endpoint, path, query, limit,
+                                             offset, summarize_by, count_by,
+                                             count_filter))
 
         url = self._url(endpoint, path=path)
         headers = {
@@ -255,7 +258,7 @@ class BaseAPI(object):
 
         if not (payload):
             payload = None
-        
+
         try:
             r = requests.get(url, params=payload, headers=headers,
                              verify=self.ssl, cert=(self.ssl_cert,
@@ -266,7 +269,7 @@ class BaseAPI(object):
             # get total number of results if requested with include-total
             # just a quick hack - needs improvement
             if 'X-Records' in r.headers:
-                self.last_total = r.headers['X-Records']        
+                self.last_total = r.headers['X-Records']
             else:
                 self.last_total = None
 

--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -162,15 +162,22 @@ class API(BaseAPI):
                 event['resource-type'],
                 )
 
-    def event_counts(self, query, summarize_by, count_by=None, count_filter=None):
+    def event_counts(self, query, summarize_by,
+                     count_by=None, count_filter=None):
         """Get event counts from puppetdb"""
-        return self._query('event-counts', query=query, summarize_by=summarize_by, count_by=count_by, count_filter=count_filter)
-	
-    def aggregate_event_counts(self, query, summarize_by, count_by=None, count_filter=None):
+        return self._query('event-counts',
+                           query=query,
+                           summarize_by=summarize_by,
+                           count_by=count_by,
+                           count_filter=count_filter)
+
+    def aggregate_event_counts(self, query, summarize_by,
+                               count_by=None, count_filter=None):
         """Get event counts from puppetdb"""
-        return self._query('aggregate-event-counts', query=query, summarize_by=summarize_by, count_by=count_by, count_filter=count_filter)
-	
+        return self._query('aggregate-event-counts',
+                           query=query, summarize_by=summarize_by,
+                           count_by=count_by, count_filter=count_filter)
+
     def server_time(self):
         """Get the current time of the clock on the PuppetDB server"""
         return self._query('server-time')['server-time']
-        

--- a/tests/baseapi/test_query.py
+++ b/tests/baseapi/test_query.py
@@ -88,12 +88,14 @@ def test_query_endpoint_path_query(api3, stub_get):
                            query='["=", "name", "host1"]')
     assert response == []
 
+
 def test_query_endpoint_query(api3, stub_get):
     url = ('http://localhost:8080/v3/nodes?query=%5B%22%3D%22%2C'
            '+%22name%22%2C+%22host1%22%5D')
     stub_get('{0}'.format(url), body='[]')
     response = api3._query('nodes', query='["=", "name", "host1"]')
     assert response == []
+
 
 def test_query_endpoint_query(api3, stub_get):
     url = ('http://localhost:8080/v3/nodes?query=%5B%22%3D%22%2C'

--- a/tests/baseapi/test_url.py
+++ b/tests/baseapi/test_url.py
@@ -119,4 +119,3 @@ def test_url_aggregate_event_counts(api3):
 def test_url_server_time(api3):
     url = api3._url('server-time')
     assert url == 'http://localhost:8080/v3/server-time'
-


### PR DESCRIPTION
- Add new Endpoints event-counts, aggregate-event-counts, server-time can be requested using _query method
- Add new parameters summarize_by, count_by, count_filter added for event-counts and aggregate-event-counts
- Add support for include-total to fetch total number of results
- Add basic query paging support to _query method with parameters: order_by, limit, offset
- Add wrapper api methods for event_counts, aggregate_event_counts, server_time
