### PR TITLE
Except HTTPError for puppetdb  error feedback

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -290,6 +290,11 @@ class BaseAPI(object):
                                                      self.host, self.port,
                                                      self.protocol.upper()))
             raise
+        except requests.exceptions.HTTPError as err:
+            log.error("{0} {1}:{2} over {3}.".format(err.response.text,
+                                                     self.host, self.port,
+                                                     self.protocol.upper()))
+            raise
 
     # Method stubs
 


### PR DESCRIPTION
Added a large "net" for requests.exceptions.HTTPError exceptions to catch
errors raised by the remote puppetdb api server.

It will log the raise_for_status() exceptions into the log buffer for
debugging errors.

This patch ignores issue #5
## 

Example error without this patch

```

Traceback (most recent call last):
  File "./example.py", line 30, in <module>
    for single_resource in allmynodesresouces:
  File "/home/dlawrence/github/pypuppetdb/pypuppetdb/api/v3.py", line 168, in resources
    resources = self._query('resources', path=path, query=query)
  File "/home/dlawrence/github/pypuppetdb/pypuppetdb/api/__init__.py", line 267, in _query
    r.raise_for_status()
  File "/home/dlawrence/.virtualenvs/nagiosdb/local/lib/python2.7/site-packages/requests/models.py", line 725, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Server Error

```

Same error with this patch

```
2013-11-09 12:40:58,822 - pypuppetdb.api - ERROR - Query returns more than the maximum number of results (max: 20000) puppetdb:8080 over HTTP.
Traceback (most recent call last):
  File "./example.py", line 30, in <module>
    for single_resource in allmynodesresouces:
  File "/home/dlawrence/github/pypuppetdb/pypuppetdb/api/v3.py", line 168, in resources
    resources = self._query('resources', path=path, query=query)
  File "/home/dlawrence/github/pypuppetdb/pypuppetdb/api/__init__.py", line 267, in _query
    r.raise_for_status()
  File "/home/dlawrence/.virtualenvs/nagiosdb/local/lib/python2.7/site-packages/requests/models.py", line 725, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Server Error

```
