### PR TITLE
Allow for resources to queried without type_

### DIFF
--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -149,6 +149,8 @@ class API(BaseAPI):
         """Query for resources limited by either type and/or title or query.
         This will yield a Resources object for every returned resource."""
 
+        path = None
+
         if type_ is not None:
             # Need to capitalize the resource type since PuppetDB doesn't
             # answer to lower case type names.
@@ -158,12 +160,10 @@ class API(BaseAPI):
                 path = '{0}/{1}'.format(type_, title)
             elif title is None:
                 path = type_
-        else:
+        elif query is None:
             log.debug('Going to query for all resources. This is usually a '
                       'bad idea as it might return enormous amounts of '
                       'resources.')
-            query = ''
-            path = None
 
         resources = self._query('resources', path=path, query=query)
         for resource in resources:


### PR DESCRIPTION
This will allow the user to query puppetdb for resrouces that do not
match a defined type.

---

It will still write to the log if both type_ and query are None. 
However it will allow for an empty type_ inlue of a query.
