### PR TITLE
Fixes failing resource queries for types including a double colon ('::')

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -145,6 +145,16 @@ class BaseAPI(object):
         if self.last_total is not None:
             return int(self.last_total)
 
+    def _normalize_resource_type(self, type_):
+        """Normalizes the type passed to the api by capitalizing each part
+        of the type. For example:
+
+        sysctl::value -> Sysctl::Value
+        user -> User
+
+        """
+        return '::'.join([s.capitalize() for s in type_.split('::')])
+
     def _url(self, endpoint, path=None):
         """The complete URL we will end up querying. Depending on the
         endpoint we pass in  this will result in different URL's with

--- a/pypuppetdb/api/v2.py
+++ b/pypuppetdb/api/v2.py
@@ -93,10 +93,8 @@ class API(BaseAPI):
         This will yield a Resources object for every returned resource."""
 
         if type_ is not None:
-            # Need to capitalize the resource type since PuppetDB doesn't
-            # answer to lower case type names.
-            # bugs.puppetlabs.com/some_value
-            type_ = type_.capitalize()
+            type_ = self._normalize_resource_type(type_)
+
             if title is not None:
                 path = '{0}/{1}'.format(type_, title)
             elif title is None:

--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -151,10 +151,8 @@ class API(BaseAPI):
         This will yield a Resources object for every returned resource."""
 
         if type_ is not None:
-            # Need to capitalize the resource type since PuppetDB doesn't
-            # answer to lower case type names.
-            # bugs.puppetlabs.com/some_value
-            type_ = type_.capitalize()
+            type_ = self._normalize_resource_type(type_)
+            
             if title is not None:
                 path = '{0}/{1}'.format(type_, title)
             elif title is None:


### PR DESCRIPTION
Currently pypuppetdb fails to query for types containing a double colon:

```
db.resource('Sysctl::Value')
```

The reason is that 'capitalize' will actually lowercase everything but the first character. `Sysctl::Value` becomes `Sysctl::value` which puppetdb won't accept.

This patch ensures that types will always have the correct cases. So these calls are now possible:

```
db.resource('sysctl::value')
db.resource('Sysctl::Value')
```

The existing queries still work of course.
