### PR TITLE
api/v3: add order_by and limit parameters to events method

### DIFF
--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -199,12 +199,12 @@ class API(BaseAPI):
                 report['transaction-uuid']
                 )
 
-    def events(self, query):
+    def events(self, query, order_by=None, limit=None):
         """A report is made up of events. This allows to query for events
         based on the reprt hash.
         This yields an Event object for every returned event."""
 
-        events = self._query('events', query=query)
+        events = self._query('events', query=query, order_by=order_by, limit=limit)
         for event in events:
             yield Event(
                 event['certname'],


### PR DESCRIPTION
Report lists for nodes tend to list all reports even if they have no events. This can lead to
clicking through several blank reports until you find the correct one.

I'm looking to create a page for the dashboard to enable us to see the most recent events by node.
Default number of events will be configurable, and can be overridden via query string.
