### PR TITLE
added missing copyright statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,8 @@ License
 This project is licensed under the Apache v2.0 License. As such, your
 contributions, once accepted, are automatically covered by this license.
 
+Copyright (c) 2013-2014 Daniele Sluijters
+
 Commit messages
 ---------------
 Write decent commit messages. Don't use swear words and refrain from


### PR DESCRIPTION
I added the missing copyright statement to your pypuppetdb for Debian.

If you merge this PR, please release a new version to pypi
