### PR TITLE
Add python-setuptools as a build requirement for bdist_rpm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ markers =
 
 [wheel]
 universal = 1
+
+[bdist_rpm]
+build_requires = python-setuptools


### PR DESCRIPTION
This is so the so the resulting SRPM can be rebuilt with mock
