### PR TITLE
pypuppetdb/types.py: Deprecating the events() function of the Report …

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -811,5 +811,6 @@ class BaseAPI(object):
                 logs=report['logs']['data'],
                 code_id=report.get('code_id'),
                 catalog_uuid=report.get('catalog_uuid'),
-                cached_catalog_status=report.get('cached_catalog_status')
+                cached_catalog_status=report.get('cached_catalog_status'),
+                events=report['resource_events']['data']
             )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -228,6 +228,41 @@ class TestReport(object):
         assert unicode(report) == unicode('hash#')
         assert repr(report) == str('Report: hash#')
 
+    def test_report_with_event(self):
+        report = Report('_', 'node2.puppet.board', 'hash#',
+                        '2015-08-31T21:07:00.000Z',
+                        '2015-08-31T21:09:00.000Z',
+                        '2015-08-31T21:10:00.000Z',
+                        '1482347613', 4, '4.2.1',
+                        'af9f16e3-75f6-4f90-acc6-f83d6524a6f3',
+                        events=[{
+                            "status": "success",
+                            "timestamp": '2015-08-31T21:09:00.000Z',
+                            "old_value": "file",
+                            "resource_title": "/etc/httpd/conf.d/README",
+                            "containment_path": [
+                                "Stage['main']",
+                                "Apache",
+                                "File[/etc/httpd/conf.d/README]"
+                            ],
+                            "file": None,
+                            "new_value": "absent",
+                            "message": "removed",
+                            "property": "ensure",
+                            "line": None,
+                            "resource_type": "File",
+                            "containing_class": "Apache"}])
+        assert report.node == 'node2.puppet.board'
+        assert report.hash_ == 'hash#'
+        assert report.start == json_to_datetime('2015-08-31T21:07:00.000Z')
+        assert report.end == json_to_datetime('2015-08-31T21:09:00.000Z')
+        assert report.received == json_to_datetime('2015-08-31T21:10:00.000Z')
+        assert report.version == '1482347613'
+        assert report.format_ == 4
+        assert report.agent_version == '4.2.1'
+        assert report.run_time == report.end - report.start
+        assert len(report.events) == 1
+
 
 class TestEvent(object):
     """Test the Event object."""


### PR DESCRIPTION
…object with an events variable.

This fixes https://github.com/voxpupuli/pypuppetdb/issues/75

This events variable is a list of Event objects that are by default
available in a Report returned from PuppetDB. Loading this information
at the beginning as opposed to querying PuppetDB for it when needed.

This sacrifices memory in favour of being infinitely iterable. The
primary application for this is to refactor the PuppetBoard Status Counts
processing.