### PR TITLE
pypuppetdb/types.py: Remove :class:`pypuppetdb.types.Report` events

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -811,6 +811,5 @@ class BaseAPI(object):
                 logs=report['logs']['data'],
                 code_id=report.get('code_id'),
                 catalog_uuid=report.get('catalog_uuid'),
-                cached_catalog_status=report.get('cached_catalog_status'),
-                events=report['resource_events']['data']
+                cached_catalog_status=report.get('cached_catalog_status')
             )

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -134,9 +134,6 @@ class Report(object):
         error. Can be one of 'explicitly_requested', 'on_failure',\
         'not_used' not 'null'.
     :type cached_catalog_status: :obj:`string`
-    :param events: (Optional) All the resource events that changed in this\
-        report.
-    :type events: :obj:`list`
 
     :ivar node: The hostname this report originated from.
     :ivar hash\_: Unique identifier of this report.
@@ -163,15 +160,12 @@ class Report(object):
     :ivar cached_catalog_status: :obj:`string` identifying if this Puppet run\
         used a cached catalog, if so weather it was a result of an error or\
         otherwise.
-    :ivar events: :obj:`list` of :class:`pypuppetdb.types.Event` objects\
-        that occured in this report run. This replaces\
-        :func:`pypuppetdb.types.Report.events`.
     """
     def __init__(self, api, node, hash_, start, end, received, version,
                  format_, agent_version, transaction, status=None,
                  metrics={}, logs={}, environment=None,
                  noop=False, code_id=None, catalog_uuid=None,
-                 cached_catalog_status=None, events=[]):
+                 cached_catalog_status=None):
 
         self.node = node
         self.hash_ = hash_
@@ -190,28 +184,10 @@ class Report(object):
         self.code_id = code_id
         self.catalog_uuid = catalog_uuid
         self.cached_catalog_status = cached_catalog_status
-        self.events = []
         self.__string = '{0}'.format(self.hash_)
 
         self.__api = api
         self.__query_scope = '["=", "report", "{0}"]'.format(self.hash_)
-
-        for event in events:
-            e = Event(node=self.node,
-                      status=event['status'],
-                      timestamp=event['timestamp'],
-                      hash_=self.hash_,
-                      title=event['resource_title'],
-                      property_=event['property'],
-                      message=event['message'],
-                      new_value=event['new_value'],
-                      old_value=event['old_value'],
-                      type_=event['resource_type'],
-                      class_=event['containing_class'],
-                      execution_path=event['containment_path'],
-                      source_file=event['file'],
-                      line_number=event['line'])
-            self.events.append(e)
 
     def __repr__(self):
         return str('Report: {0}'.format(self.__string))
@@ -225,11 +201,7 @@ class Report(object):
     def events(self, **kwargs):
         """Get all events for this report. Additional arguments may also be
         specified that will be passed to the query function.
-
-        This function has been deprecated in favour of the events variable.
         """
-        log.warn("Use of :func:`pypuppetdb.types.Report.events` has been\
-                 deprecated in favour of the events variable.")
         return self.__api.events(query=self.__query_scope, **kwargs)
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -228,41 +228,6 @@ class TestReport(object):
         assert unicode(report) == unicode('hash#')
         assert repr(report) == str('Report: hash#')
 
-    def test_report_with_event(self):
-        report = Report('_', 'node2.puppet.board', 'hash#',
-                        '2015-08-31T21:07:00.000Z',
-                        '2015-08-31T21:09:00.000Z',
-                        '2015-08-31T21:10:00.000Z',
-                        '1482347613', 4, '4.2.1',
-                        'af9f16e3-75f6-4f90-acc6-f83d6524a6f3',
-                        events=[{
-                            "status": "success",
-                            "timestamp": '2015-08-31T21:09:00.000Z',
-                            "old_value": "file",
-                            "resource_title": "/etc/httpd/conf.d/README",
-                            "containment_path": [
-                                "Stage['main']",
-                                "Apache",
-                                "File[/etc/httpd/conf.d/README]"
-                            ],
-                            "file": None,
-                            "new_value": "absent",
-                            "message": "removed",
-                            "property": "ensure",
-                            "line": None,
-                            "resource_type": "File",
-                            "containing_class": "Apache"}])
-        assert report.node == 'node2.puppet.board'
-        assert report.hash_ == 'hash#'
-        assert report.start == json_to_datetime('2015-08-31T21:07:00.000Z')
-        assert report.end == json_to_datetime('2015-08-31T21:09:00.000Z')
-        assert report.received == json_to_datetime('2015-08-31T21:10:00.000Z')
-        assert report.version == '1482347613'
-        assert report.format_ == 4
-        assert report.agent_version == '4.2.1'
-        assert report.run_time == report.end - report.start
-        assert len(report.events) == 1
-
 
 class TestEvent(object):
     """Test the Event object."""


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/pypuppetdb/issues/81
This undoes https://github.com/voxpupuli/pypuppetdb/pull/76

This new functionality was not thoroughly tested, the main symtom is that
the timestamps returned by the expanded resource events data are in a
format that Python cannot parse. Namely tiemzones are returned with -04:00
and Python 2.x cannot parse that, not sure about Python 3.