### PR TITLE
Revert "pypuppetdb/api/__init__/facts: Replacing the path extensions …

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -522,16 +522,13 @@ class BaseAPI(object):
         :rtype: :class:`pypuppetdb.types.Fact`
         """
         if name is not None and value is not None:
-            query = '["and",' \
-                '["=", "name", "{0}"],' \
-                '["=", "value", "{1}"]]'.format(
-                    name, value)
+            path = '{0}/{1}'.format(name, value)
         elif name is not None and value is None:
-            query = '["=", "name", "{0}"]'.format(name)
+            path = name
         else:
-            query = None
+            path = None
 
-        facts = self._query('facts', query=query, **kwargs)
+        facts = self._query('facts', path=path, **kwargs)
         for fact in facts:
             yield Fact(
                 node=fact['certname'],


### PR DESCRIPTION
…with their query string equivalents (#68)"

This reverts commit 26176607d4292460a146d7eaae35661356113c5b.
This fixes https://github.com/voxpupuli/pypuppetdb/issues/84