### PR TITLE
pypuppetdb/api/__init__/_url: URL Escaping special characters passed …

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-import logging
-
 import json
+import logging
 import requests
 
 from datetime import datetime, timedelta
@@ -17,6 +16,11 @@ from pypuppetdb.types import (
     Node, Fact, Resource,
     Report, Event, Catalog
 )
+
+try:
+    from urllib import quote
+except ImportError:
+    from urllib.parse import quote
 
 log = logging.getLogger(__name__)
 
@@ -236,7 +240,7 @@ class BaseAPI(object):
         )
 
         if path is not None:
-            url = '{0}/{1}'.format(url, path)
+            url = '{0}/{1}'.format(url, quote(path))
 
         return url
 

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -151,6 +151,12 @@ class TestBaseAPIURL(object):
         assert url == \
             'http://localhost:8080/pdb/query/v4/nodes/node1.example.com'
 
+    def test_quote(self, baseapi):
+        url = baseapi._url("facts", path="macaddress/02:42:ec:94:80:f0")
+        assert url == \
+            'http://localhost:8080/pdb/query/v4/' \
+            + 'facts/macaddress/02%3A42%3Aec%3A94%3A80%3Af0'
+
 
 class TesteAPIQuery(object):
     @mock.patch.object(requests.Session, 'request')


### PR DESCRIPTION
…as additional path arguments

This fixes https://github.com/voxpupuli/pypuppetdb/issues/67

If a query with a passed path argument will be subject to a urllib quote
to escape special characters.
Slight adjustment to imports.