### PR TITLE
pypuppetdb/types.py: Adding support for additional Nodes endpoint fie…

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -427,20 +427,24 @@ class BaseAPI(object):
                         node['status'] = 'unchanged'
 
                 # node report age
-                try:
-                    last_report = json_to_datetime(
-                        node['report_timestamp']).replace(tzinfo=None)
-                    now = datetime.utcnow()
-                    unreported_border = now - timedelta(hours=unreported)
-                    if last_report < unreported_border:
-                        delta = (now - last_report)
+                if node['report_timestamp'] is not None:
+                    try:
+                        last_report = json_to_datetime(
+                            node['report_timestamp']).replace(tzinfo=None)
+                        now = datetime.utcnow()
+                        unreported_border = now - timedelta(hours=unreported)
+                        if last_report < unreported_border:
+                            delta = (now - last_report)
+                            node['status'] = 'unreported'
+                            node['unreported_time'] = '{0}d {1}h {2}m'.format(
+                                delta.days,
+                                int(delta.seconds / 3600),
+                                int((delta.seconds % 3600) / 60)
+                            )
+                    except AttributeError:
                         node['status'] = 'unreported'
-                        node['unreported_time'] = '{0}d {1}h {2}m'.format(
-                            delta.days,
-                            int(delta.seconds / 3600),
-                            int((delta.seconds % 3600) / 60)
-                        )
-                except (AttributeError, KeyError):
+
+                if not node['report_timestamp']:
                     node['status'] = 'unreported'
 
             yield Node(self,

--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -460,7 +460,9 @@ class BaseAPI(object):
                        report_environment=node['report_environment'],
                        catalog_environment=node['catalog_environment'],
                        facts_environment=node['facts_environment'],
-                       latest_report_hash=node.get('latest_report_hash')
+                       latest_report_hash=node.get('latest_report_hash'),
+                       cached_catalog_status=node.get('cached_catalog_status'),
+                       latest_report_noop=node.get('latest_report_noop')
                        )
 
     def node(self, name):

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -344,6 +344,13 @@ class Node(object):
     :param latest_report_hash: The hash of the latest report from this node,\
             is only available in PuppetDB 3.2 and later
     :type latest_report_hash: :obj:`string`
+    :param cached_catalog_status: Cached catalog status of the last puppet run\
+            on this node, possible values are 'explicitly_requested',\
+            'on_failure', 'not_used' or None.
+    :type cache_catalog_status: :obj:`string`
+    :param latest_report_noop: Determines weather the latest report was\
+            generated with the '--noop' flag.
+    :type latest_report_noop: :obj:`bool`
 
     :ivar name: Hostname of this node.
     :ivar deactivated: :obj:`datetime.datetime` when this host was\
@@ -363,6 +370,10 @@ class Node(object):
     :ivar latest_report_hash: :obj:`string` the hash value of the latest\
             report the current node reported. Available in PuppetDB 3.2\
             and later.
+    :ivar cached_catalog_status: :obj:`string` the status of the cached\
+            catalog from the last puppet run.
+    :ivar latest_report_noop: :obj:`bool` the latest report run with the\
+            '--noop' flag.
     """
     def __init__(self, api, name, deactivated=None, expired=None,
                  report_timestamp=None, catalog_timestamp=None,
@@ -370,7 +381,8 @@ class Node(object):
                  unreported_time=None, report_environment='production',
                  catalog_environment='production',
                  facts_environment='production',
-                 latest_report_hash=None):
+                 latest_report_hash=None, cached_catalog_status=None,
+                 latest_report_noop=None):
         self.name = name
         self.status = status
         self.events = events
@@ -382,6 +394,8 @@ class Node(object):
         self.catalog_environment = catalog_environment
         self.facts_environment = facts_environment
         self.latest_report_hash = latest_report_hash
+        self.cached_catalog_status = cached_catalog_status
+        self.latest_report_noop = latest_report_noop
 
         if deactivated is not None:
             self.deactivated = json_to_datetime(deactivated)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -104,6 +104,22 @@ class TestNode(object):
         assert node.name == 'node'
         assert node.latest_report_hash == 'hash#1'
 
+    def test_with_cached_catalog_status(self):
+        node1 = Node('_', 'node', cached_catalog_status='explicitly_requested')
+        node2 = Node('_', 'node', cached_catalog_status='on_failure')
+        node3 = Node('_', 'node', cached_catalog_status='not_used')
+        assert node1.name == 'node'
+        assert node1.cached_catalog_status == 'explicitly_requested'
+        assert node2.name == 'node'
+        assert node2.cached_catalog_status == 'on_failure'
+        assert node3.name == 'node'
+        assert node3.cached_catalog_status == 'not_used'
+
+    def test_with_latest_report_noop(self):
+        node = Node('_', 'node', latest_report_noop=False)
+        assert node.name == 'node'
+        assert not node.latest_report_noop
+
 
 class TestFact(object):
     """Test the Fact object."""


### PR DESCRIPTION
…ld results in PuppetDB 4.1.0

This fixes https://github.com/voxpupuli/pypuppetdb/issues/87

PuppetDB 4.1.0 introduced the cached_catalog_status and latest_report_noop
fields on the Nodes endpoint. Adding support for those fields in types and
updating test cases.

Also doing some cleanup of `pypuppetdb.api.BaseAPI.nodes()`