### PR TITLE
pypuppetdb/types.py: fix Python3 compatibility

### DIFF
--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -572,7 +572,10 @@ class Catalog(object):
         return self.__string
 
     def get_resources(self):
-        return self.resources.itervalues()
+        try:
+            return self.resources.itervalues()
+        except AttributeError:
+            return self.resources.values()
 
     def get_resource(self, resource_type, resource_title):
         identifier = resource_type + \


### PR DESCRIPTION
Use `dict.itervalues()` by default, but fall back to `dict.values()` if it doesn't exist.