### PR TITLE
Query builder

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -100,6 +100,49 @@ In that case, we'll throw an exception at you.
 .. autoexception:: pypuppetdb.errors.EmptyResponseError
    :show-inheritance:
 
+Query Builder
+-------------
+
+With the increasing complexities of some queries it can be very difficult
+to maintain query strings as string objects. The 0.3.0 release introduces
+a new feature called the Query Builder which removes the need of string
+object concatenation into an Object-Oriented fashion.
+
+In order to create the following query:
+
+``'["and", ["=", "facts_environment", "production"], ["=", "catalog_environment", "production"]]'``
+
+Users can use the following code block to create the same thing:
+
+.. code-block:: python
+
+   >>> op = AndOperator()
+   >>> op.add(EqualOperator("facts_environment", "production"))
+   >>> op.add(EqualOperator("catalog_environment", "production"))
+
+The ``op`` object can then be directly input to the query parameter of any
+PuppetDB call.
+
+.. autoclass:: pypuppetdb.QueryBuilder.BinaryOperator
+   :members:
+.. autoclass:: pypuppetdb.QueryBuilder.EqualsOperator
+.. autoclass:: pypuppetdb.QueryBuilder.GreaterOperator
+.. autoclass:: pypuppetdb.QueryBuilder.LessOperator
+.. autoclass:: pypuppetdb.QueryBuilder.GreaterEqualOperator
+.. autoclass:: pypuppetdb.QueryBuilder.LessEqualOperator
+.. autoclass:: pypuppetdb.QueryBuilder.RegexOperator
+.. autoclass:: pypuppetdb.QueryBuilder.RegexArrayOperator
+.. autoclass:: pypuppetdb.QueryBuilder.NullOperator
+.. autoclass:: pypuppetdb.QueryBuilder.BooleanOperator
+   :members:
+.. autoclass:: pypuppetdb.QueryBuilder.AndOperator
+.. autoclass:: pypuppetdb.QueryBuilder.OrOperator
+.. autoclass:: pypuppetdb.QueryBuilder.NotOperator
+.. autoclass:: pypuppetdb.QueryBuilder.ExtractOperator
+   :members:
+.. autoclass:: pypuppetdb.QueryBuilder.FunctionOperator
+   :members:
+
 Utilities
 ---------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -116,12 +116,17 @@ Users can use the following code block to create the same thing:
 
 .. code-block:: python
 
+   >>> from pypuppetdb.QueryBuilder import *
    >>> op = AndOperator()
    >>> op.add(EqualOperator("facts_environment", "production"))
    >>> op.add(EqualOperator("catalog_environment", "production"))
 
 The ``op`` object can then be directly input to the query parameter of any
 PuppetDB call.
+
+.. code-block:: python
+
+   >>> pypuppetdb.nodes(query=op)
 
 .. autoclass:: pypuppetdb.QueryBuilder.BinaryOperator
    :members:

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -1,0 +1,170 @@
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class BinaryOperator(object):
+    """
+    This is a parent helper class used to create PuppetDB AST queries
+    for single key-value pairs for the available operators. See
+    https://docs.puppet.com/puppetdb/4.0/api/query/v4/ast.html#binary-operators
+    for more information.
+
+    :param operator: The binary query operation performed. There is
+        no value checking on this field.
+    :type operator: :obj:`string`
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: The values of the field to match, or not match.
+    :type value: any
+    """
+    def __init__(self, operator, field, value):
+        self.operator = operator
+        self.field = field
+
+        if type(value) == str:
+            self.value = '"' + value + '"'
+        else:
+            self.value = value
+
+        self.__string = '["{0}", "{1}", {2}]'.format(
+            self.operator,
+            self.field,
+            self.value)
+
+    def __repr__(self):
+        return str('Query: {0}'.format(self.__string))
+
+    def __str__(self):
+        return str('{0}'.format(self.__string))
+
+    def __unicode__(self):
+        return self.__string
+
+
+class EqualsOperator(BinaryOperator):
+    """
+    Builds an equality filter based on the supplied field-value pair.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: The value of the field to match, or not match.
+    :type value: any
+    """
+    def __init__(self, field, value):
+        super(EqualsOperator, self).__init__("=", field, value)
+
+
+class GreaterOperator(BinaryOperator):
+    """
+    Builds a greater-than filter based on the supplied field-value pair.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field is greater than this value.
+    :type value: Number, timestamp or array
+    """
+    def __init__(self, field, value):
+        super(GreaterOperator, self).__init__(">", field, value)
+
+
+class LessOperator(BinaryOperator):
+    """
+    Builds a less-than filter based on the supplied field-value pair.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field is less than this value.
+    :type value: Number, timestamp or array
+    """
+    def __init__(self, field, value):
+        super(LessOperator, self).__init__("<", field, value)
+
+
+class GreaterEqualOperator(BinaryOperator):
+    """
+    Builds a greater-than or equal-to filter based on the supplied
+    field-value pair.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field is greater than or equal to\
+        this value.
+    :type value: Number, timestamp or array
+    """
+    def __init__(self, field, value):
+        super(GreaterEqualOperator, self).__init__(">=", field, value)
+
+
+class LessEqualOperator(BinaryOperator):
+    """
+    Builds a less-than or equal-to filter based on the supplied
+    field-value pair.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field is less than or equal to\
+        this value.
+    :type value: Number, timestamp or array
+    """
+    def __init__(self, field, value):
+        super(LessEqualOperator, self).__init__("<=", field, value)
+
+
+class RegexOperator(BinaryOperator):
+    """
+    Builds a regular expression filter based on the supplied field-value
+    pair.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field matches this regular expression.
+    :type value: :obj:`string`
+    """
+    def __init__(self, field, value):
+        super(RegexOperator, self).__init__("~", field, value)
+
+
+class RegexArrayOperator(BinaryOperator):
+    """
+    Builds a regular expression array filter based on the supplied
+    field-value pair. This query only works on fields with paths.
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field matches this regular expression.
+    :type value: :obj:`list`
+    """
+    def __init__(self, field, value):
+        super(RegexArrayOperator, self).__init__("~>", field, value)
+
+
+class NullOperator(BinaryOperator):
+    """
+    Builds a null filter based on the field and boolean value pair.
+    This filter only works on field that may be null. Value may only
+    be True or False
+
+    :param field: The PuppetDB endpoint query field. See endpoint
+                  documentation for valid values.
+    :type field: any
+    :param value: Matches if the field value is null (if True) or\
+        not null (if False)
+    :type value: :obj:`bool`
+    """
+    def __init__(self, field, value):
+        if type(value) != bool:
+            raise ValueError("NullOperator value must be boolean")
+
+        super(NullOperator, self).__init__("null?", field, value)

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -136,7 +136,35 @@ class ExtractOperator(object):
             raise APIError("ExtractOperator.add_group_by only supports "
                            "lists and strings")
 
+    def __repr__(self):
+        if len(self.fields) == 0:
+            raise APIError("ExtractOperator needs at least one field")
+
+        arr = ['"extract"']
+        arr.append("[{0}]".format(",".join(self.fields)))
+
+        if self.query is not None:
+            arr.append(self.query)
+        if len(self.group_by) > 0:
+            arr.append("[{0}]".format(",".join(self.group_by)))
+
+        return str('Query: [{0}]'.format(",".join(arr)))
+
     def __str__(self):
+        if len(self.fields) == 0:
+            raise APIError("ExtractOperator needs at least one field")
+
+        arr = ['"extract"']
+        arr.append("[{0}]".format(",".join(self.fields)))
+
+        if self.query is not None:
+            arr.append(self.query)
+        if len(self.group_by) > 0:
+            arr.append("[{0}]".format(",".join(self.group_by)))
+
+        return str('[{0}]'.format(",".join(arr)))
+
+    def __unicode__(self):
         if len(self.fields) == 0:
             raise APIError("ExtractOperator needs at least one field")
 

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -50,6 +50,44 @@ class BinaryOperator(object):
         return self.__string
 
 
+class BooleanOperator(object):
+    """
+    This is a parent helper class used to create PuppetDB AST queries
+    for available boolean queries. See
+    https://docs.puppet.com/puppetdb/4.0/api/query/v4/ast.html#binary-operators
+    for more information.
+
+    :param operator: The boolean query operation to perform.
+    :type operator: :obj:`string`
+    """
+    def __init__(self, operator):
+        self.operator = operator
+        self.operations = []
+
+    def add(self, query):
+        if type(query) == list:
+            for i in query:
+                self.add(i)
+        elif (type(query) == str or
+                isinstance(query, (BinaryOperator, BooleanOperator))):
+            self.operations.append(str(query))
+        else:
+            raise ValueError("Can only accpet fixed-string queries, arrays " +
+                             "or operator objects")
+
+    def __repr__(self):
+        return 'Query: ["{0}",{1}]'.format(self.operator,
+                                           ",".join(self.operations))
+
+    def __str__(self):
+        return str('["{0}",{1}]'.format(self.operator,
+                   ",".join(self.operations)))
+
+    def __unicode__(self):
+        return '["{0}",{1}]'.format(self.operator,
+                                    ",".join(self.operations))
+
+
 class EqualsOperator(BinaryOperator):
     """
     Builds an equality filter based on the supplied field-value pair.
@@ -172,3 +210,13 @@ class NullOperator(BinaryOperator):
             raise ValueError("NullOperator value must be boolean")
 
         super(NullOperator, self).__init__("null?", field, value)
+
+
+class AndOperator(BooleanOperator):
+    """
+    Builds an AND boolean filter. Only results that match ALL
+    criteria from the included query strings will be returned
+    from PuppetDB.
+    """
+    def __init__(self):
+        super(AndOperator, self).__init__("and")

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+import datetime
 import logging
 import sys
 
@@ -43,7 +44,7 @@ class BinaryOperator(object):
         else:
             field = field
 
-        if isinstance(value, (str, unicode)):
+        if isinstance(value, (str, unicode, datetime.datetime)):
             value = '"{0}"'.format(value)
         elif isinstance(value, bool):
             value = 'true' if value else 'false'

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -260,6 +260,14 @@ class EqualsOperator(BinaryOperator):
     described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#equality.
 
+    In order to create the following query:
+
+    ["=", "environment", "production"]
+
+    The following code can be used.
+
+    EqualsOperator('environment', 'production')
+
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
     :type field: any
@@ -275,6 +283,14 @@ class GreaterOperator(BinaryOperator):
     Builds a greater-than filter based on the supplied field-value pair as
     described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#greater-than.
+
+    In order to create the following query:
+
+    [">", "catalog_timestamp", "2016-06-01 00:00:00"]
+
+    The following code can be used.
+
+    GreaterOperator('catalog_timestamp', datetime.datetime(2016, 06, 01))
 
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
@@ -292,6 +308,14 @@ class LessOperator(BinaryOperator):
     described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#less-than.
 
+    In order to create the following query:
+
+    ["<", "catalog_timestamp", "2016-06-01 00:00:00"]
+
+    The following code can be used.
+
+    LessOperator('catalog_timestamp', datetime.datetime(2016, 06, 01))
+
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
     :type field: any
@@ -307,6 +331,14 @@ class GreaterEqualOperator(BinaryOperator):
     Builds a greater-than or equal-to filter based on the supplied
     field-value pair as described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#greater-than-or-equal-to.
+
+    In order to create the following query:
+
+    [">=", "facts_timestamp", "2016-06-01 00:00:00"]
+
+    The following code can be used.
+
+    GreaterEqualOperator('facts_timestamp', datetime.datetime(2016, 06, 01))
 
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
@@ -325,6 +357,14 @@ class LessEqualOperator(BinaryOperator):
     field-value pair as described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#less-than-or-equal-to.
 
+    In order to create the following query:
+
+    ["<=", "facts_timestamp", "2016-06-01 00:00:00"]
+
+    The following code can be used.
+
+    LessEqualOperator('facts_timestamp', datetime.datetime(2016, 06, 01))
+
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
     :type field: any
@@ -341,6 +381,14 @@ class RegexOperator(BinaryOperator):
     Builds a regular expression filter based on the supplied field-value
     pair as described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#regexp-match.
+
+    In order to create the following query:
+
+    ["~", "certname", "www\\d+\\.example\\.com"]
+
+    The following code can be used.
+
+    RegexOperator('certname', 'www\\d+\\.example\\.com')
 
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
@@ -359,6 +407,14 @@ class RegexArrayOperator(BinaryOperator):
     described
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#regexp-array-match.
 
+    In order to create the following query:
+
+    ["~", "path", ["networking", "eth.*", "macaddress"]]
+
+    The following code can be used.
+
+    RegexArrayOperator('path', ["networking", "eth.*", "macaddress"])
+
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
     :type field: any
@@ -376,6 +432,14 @@ class NullOperator(BinaryOperator):
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#null-is-null.
     This filter only works on field that may be null. Value may only
     be True or False.
+
+    In order to create the following query:
+
+    ["null?", "deactivated", true]
+
+    The following code can be used.
+
+    NullOperator('deactivated', True)
 
     :param field: The PuppetDB endpoint query field. See endpoint
                   documentation for valid values.
@@ -397,6 +461,18 @@ class AndOperator(BooleanOperator):
     criteria from the included query strings will be returned
     from PuppetDB. Full documentation is available
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#and
+
+    In order to create the following query:
+
+    ["and",
+      ["=", "catalog_environment", "production"],
+      ["=", "facts_environment", "production"]]
+
+    The following code can be used:
+
+    op = AndOperator()
+    op.add(EqualsOperator("catalog_environment", "production"))
+    op.add(EqualsOperator("facts_environment", "production"))
     """
     def __init__(self):
         super(AndOperator, self).__init__("and")
@@ -408,6 +484,16 @@ class OrOperator(BooleanOperator):
     criteria from the included query strings will be returned
     from PuppetDB. Full documentation is available
     https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#or.
+
+    In order to create the following query:
+
+    ["or", ["=", "name", "hostname"], ["=", "name", "architecture"]]
+
+    The following code can be used:
+
+    op = OrOperator()
+    op.add(EqualsOperator("name", "hostname"))
+    op.add(EqualsOperator("name", "architecture"))
     """
     def __init__(self):
         super(OrOperator, self).__init__("or")
@@ -422,6 +508,15 @@ class NotOperator(BooleanOperator):
 
     Unlike the other Boolean Operator objects this operator only
     accepts a single query string.
+
+    In order to create the following query:
+
+    ["not", ["=", "osfamily", "RedHat"]]
+
+    The following code can be used.
+
+    op = NotOperator()
+    op.add(EqualsOperator("osfamily", "RedHat"))
     """
     def __init__(self):
         super(NotOperator, self).__init__("not")

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -210,7 +210,9 @@ class FunctionOperator(object):
     """
     Performs an aggregate function on the result of a subquery, full
     documentation is available at
-    https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#function
+    https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#function.
+    This object can only be used in the field list or group by list of
+    an ExtractOperator object.
 
     :param function: The name of the function to perform.
     :type function: :obj:`str`

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -220,3 +220,31 @@ class AndOperator(BooleanOperator):
     """
     def __init__(self):
         super(AndOperator, self).__init__("and")
+
+
+class OrOperator(BooleanOperator):
+    """
+    Builds an OR boolean filter. Only results that match ANY
+    criteria from the included query strings will be returned
+    from PuppetDB.
+    """
+    def __init__(self):
+        super(OrOperator, self).__init__("or")
+
+
+class NotOperator(BooleanOperator):
+    """
+    Builds a NOT boolean filter. Only results that DO NOT match
+    criteria from the included query strings will be returned
+    from PuppetDB.
+
+    Unlike the other Boolean Operator objects this operator only
+    accepts a single query string.
+    """
+    def __init__(self):
+        super(NotOperator, self).__init__("not")
+
+    def add(self, query):
+        if len(self.operations) > 0:
+            raise ValueError("This operator only accept one query string")
+        super(NotOperator, self).add(query)

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -524,4 +524,6 @@ class NotOperator(BooleanOperator):
     def add(self, query):
         if len(self.operations) > 0:
             raise APIError("This operator only accept one query string")
+        elif isinstance(query, list) and len(query) > 1:
+            raise APIError("This operator only accept one query string")
         super(NotOperator, self).add(query)

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -2,10 +2,14 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import logging
+import sys
 
 from pypuppetdb.errors import *
 
 log = logging.getLogger(__name__)
+
+if sys.version_info >= (3, 0):
+    unicode = str
 
 
 class BinaryOperator(object):
@@ -34,13 +38,15 @@ class BinaryOperator(object):
     :type value: any
     """
     def __init__(self, operator, field, value):
-        if type(field) == str:
+        if isinstance(field, (str, unicode)):
             field = '"{0}"'.format(field)
         else:
             field = field
 
-        if type(value) == str:
+        if isinstance(value, (str, unicode)):
             value = '"{0}"'.format(value)
+        elif isinstance(value, bool):
+            value = 'true' if value else 'false'
         else:
             value = value
 

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -24,14 +24,18 @@ class BinaryOperator(object):
     """
     def __init__(self, operator, field, value):
         self.operator = operator
-        self.field = field
+
+        if type(field) == str:
+            self.field = '"' + field + '"'
+        else:
+            self.field = field
 
         if type(value) == str:
             self.value = '"' + value + '"'
         else:
             self.value = value
 
-        self.__string = '["{0}", "{1}", {2}]'.format(
+        self.__string = '["{0}", {1}, {2}]'.format(
             self.operator,
             self.field,
             self.value)

--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -297,7 +297,7 @@ class BaseAPI(object):
 
         payload = {}
         if query is not None:
-            payload['query'] = str(query)
+            payload['query'] = query
         if order_by is not None:
             payload[PARAMETERS['order_by']] = order_by
         if limit is not None:

--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -16,6 +16,7 @@ from pypuppetdb.types import (
     Node, Fact, Resource,
     Report, Event, Catalog
 )
+from pypuppetdb.QueryBuilder import *
 
 try:
     from urllib import quote
@@ -296,7 +297,7 @@ class BaseAPI(object):
 
         payload = {}
         if query is not None:
-            payload['query'] = query
+            payload['query'] = str(query)
         if order_by is not None:
             payload[PARAMETERS['order_by']] = order_by
         if limit is not None:
@@ -394,7 +395,7 @@ class BaseAPI(object):
 
         if with_status:
             latest_events = self.event_counts(
-                query='["=", "latest_report?", true]',
+                query=EqualsOperator("latest_report?", True),
                 summarize_by='certname'
             )
 

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import logging
 from pypuppetdb.utils import json_to_datetime
+from pypuppetdb.QueryBuilder import *
 
 log = logging.getLogger(__name__)
 
@@ -187,7 +188,6 @@ class Report(object):
         self.__string = '{0}'.format(self.hash_)
 
         self.__api = api
-        self.__query_scope = '["=", "report", "{0}"]'.format(self.hash_)
 
     def __repr__(self):
         return str('Report: {0}'.format(self.__string))
@@ -202,7 +202,8 @@ class Report(object):
         """Get all events for this report. Additional arguments may also be
         specified that will be passed to the query function.
         """
-        return self.__api.events(query=self.__query_scope, **kwargs)
+        return self.__api.events(query=EqualsOperator("report", self.hash_),
+                                 **kwargs)
 
 
 class Fact(object):
@@ -419,7 +420,6 @@ class Node(object):
             self.catalog_timestamp = catalog_timestamp
 
         self.__api = api
-        self.__query_scope = '["=", "certname", "{0}"]'.format(self.name)
         self.__string = self.name
 
     def __repr__(self):
@@ -435,7 +435,8 @@ class Node(object):
         """Get all facts of this node. Additional arguments may also be
         specified that will be passed to the query function.
         """
-        return self.__api.facts(query=self.__query_scope, **kwargs)
+        return self.__api.facts(query=EqualsOperator("certname", self.name),
+                                **kwargs)
 
     def fact(self, name):
         """Get a single fact from this node."""
@@ -448,16 +449,20 @@ class Node(object):
         to the query function.
         """
         if type_ is None:
-            resources = self.__api.resources(query=self.__query_scope,
-                                             **kwargs)
+            resources = self.__api.resources(
+                query=EqualsOperator("certname", self.name),
+                **kwargs)
         elif type_ is not None and title is None:
-            resources = self.__api.resources(type_=type_,
-                                             query=self.__query_scope,
-                                             **kwargs)
+            resources = self.__api.resources(
+                type_=type_,
+                query=EqualsOperator("certname", self.name),
+                **kwargs)
         else:
-            resources = self.__api.resources(type_=type_, title=title,
-                                             query=self.__query_scope,
-                                             **kwargs)
+            resources = self.__api.resources(
+                type_=type_,
+                title=title,
+                query=EqualsOperator("certname", self.name),
+                **kwargs)
         return resources
 
     def resource(self, type_, title, **kwargs):
@@ -465,16 +470,20 @@ class Node(object):
         arguments may also be specified that will be passed to the query
         function.
         """
-        resources = self.__api.resources(type_=type_, title=title,
-                                         query=self.__query_scope,
-                                         **kwargs)
+        resources = self.__api.resources(
+            type_=type_,
+            title=title,
+            query=EqualsOperator("certname", self.name),
+            **kwargs)
         return next(resource for resource in resources)
 
     def reports(self, **kwargs):
         """Get all reports for this node. Additional arguments may also be
         specified that will be passed to the query function.
         """
-        return self.__api.reports(query=self.__query_scope, **kwargs)
+        return self.__api.reports(
+            query=EqualsOperator("certname", self.name),
+            **kwargs)
 
 
 class Catalog(object):

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -21,12 +21,16 @@ class TestBinaryOperator(object):
             == '["=", "is_virtual", True]'
         assert str(EqualsOperator("bios_version", ["6.00", 5.00]))\
             == '["=", "bios_version", [\'6.00\', 5.0]]'
+        assert str(EqualsOperator(['parameter', 'ensure'], "present"))\
+            == '["=", [\'parameter\', \'ensure\'], "present"]'
 
     def test_greater_operator(self):
         assert str(GreaterOperator("uptime", 150))\
             == '[">", "uptime", 150]'
         assert str(GreaterOperator("end_time", '"2016-05-11T23:22:48.709Z"'))\
             == '[">", "end_time", ""2016-05-11T23:22:48.709Z""]'
+        assert str(GreaterOperator(['parameter', 'version'], 4.0))\
+            == '[">", [\'parameter\', \'version\'], 4.0]'
 
     def test_less_operator(self):
         assert str(LessOperator("uptime_seconds", 300))\
@@ -35,6 +39,8 @@ class TestBinaryOperator(object):
             "producer_timestamp",
             "2016-05-11T23:53:29.962Z"))\
             == '["<", "producer_timestamp", "2016-05-11T23:53:29.962Z"]'
+        assert str(LessOperator(['parameter', 'version'], 4.0))\
+            == '["<", [\'parameter\', \'version\'], 4.0]'
 
     def test_greater_equal_operator(self):
         assert str(GreaterEqualOperator("uptime_days", 3))\
@@ -43,16 +49,22 @@ class TestBinaryOperator(object):
             "start_time",
             "2016-05-11T23:53:29.962Z"))\
             == '[">=", "start_time", "2016-05-11T23:53:29.962Z"]'
+        assert str(GreaterEqualOperator(['parameter', 'version'], 4.0))\
+            == '[">=", [\'parameter\', \'version\'], 4.0]'
 
     def test_less_equal_operator(self):
         assert str(LessEqualOperator("kernelmajversion", 4))\
             == '["<=", "kernelmajversion", 4]'
         assert str(LessEqualOperator("end_time", "2016-05-11T23:53:29.962Z"))\
             == '["<=", "end_time", "2016-05-11T23:53:29.962Z"]'
+        assert str(LessEqualOperator(['parameter', 'version'], 4.0))\
+            == '["<=", [\'parameter\', \'version\'], 4.0]'
 
     def test_regex_operator(self):
         assert str(RegexOperator("certname", "www\\d+\\.example\\.com"))\
             == '["~", "certname", "www\\d+\\.example\\.com"]'
+        assert str(RegexOperator(['parameter', 'version'], "4\\.\\d+"))\
+            == '["~", [\'parameter\', \'version\'], "4\\.\\d+"]'
 
     def test_regex_array_operator(self):
         assert str(RegexArrayOperator(
@@ -67,9 +79,3 @@ class TestBinaryOperator(object):
             == '["null?", "report_environment", False]'
         with pytest.raises(ValueError):
             NullOperator("environment", "test")
-
-
-class TestBooleanOperator(object):
-    """
-    Test the BooleanOperator object and all sub-classes.
-    """

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -103,3 +103,36 @@ class TestBooleanOperator(object):
 
         with pytest.raises(ValueError):
             op.add({"query1": '["=", "catalog_environment", "production"]'})
+
+    def test_or_operator(self):
+        op = OrOperator()
+        op.add(EqualsOperator("operatingsystem", "CentOS"))
+        op.add([EqualsOperator("architecture", "x86_64"),
+                GreaterOperator("operatingsystemmajrelease", 6)])
+
+        assert str(op) == '["or",["=", "operatingsystem", "CentOS"],'\
+            '["=", "architecture", "x86_64"],'\
+            '[">", "operatingsystemmajrelease", 6]]'
+        assert repr(op) == 'Query: ["or",["=", "operatingsystem", "CentOS"],'\
+            '["=", "architecture", "x86_64"],'\
+            '[">", "operatingsystemmajrelease", 6]]'
+        assert unicode(op) == '["or",["=", "operatingsystem", "CentOS"],'\
+            '["=", "architecture", "x86_64"],'\
+            '[">", "operatingsystemmajrelease", 6]]'
+
+        with pytest.raises(ValueError):
+            op.add({"query1": '["=", "catalog_environment", "production"]'})
+
+    def test_not_operator(self):
+        op = NotOperator()
+        op.add(EqualsOperator("operatingsystem", "CentOS"))
+
+        assert str(op) == '["not",["=", "operatingsystem", "CentOS"]]'
+        assert repr(op) == 'Query: ["not",["=", "operatingsystem", "CentOS"]]'
+        assert unicode(op) == '["not",["=", "operatingsystem", "CentOS"]]'
+
+        with pytest.raises(ValueError):
+            op.add(GreaterOperator("operatingsystemmajrelease", 6))
+        with pytest.raises(ValueError):
+            op.add([EqualsOperator("architecture", "x86_64"),
+                    GreaterOperator("operatingsystemmajrelease", 6)])

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -189,6 +189,13 @@ class TestBooleanOperator(object):
         with pytest.raises(APIError):
             unicode(op)
 
+    def test_not_with_list(self):
+        op = NotOperator()
+
+        with pytest.raises(APIError):
+            str(op.add([EqualsOperator('clientversion', '4.5.1'),
+                        EqualsOperator('facterversion', '3.2.0')]))
+
 
 class TestExtractOperator(object):
     """

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -31,7 +31,7 @@ class TestBinaryOperator(object):
         assert str(EqualsOperator(u"latest_report?", True))\
             == '["=", "latest_report?", true]'
         assert str(EqualsOperator("report_timestamp",
-                                  datetime.datetime(2016, 06, 11)))\
+                                  datetime.datetime(2016, 6, 11)))\
             == '["=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_greater_operator(self):
@@ -42,7 +42,7 @@ class TestBinaryOperator(object):
         assert str(GreaterOperator(['parameter', 'version'], 4.0))\
             == '[">", [\'parameter\', \'version\'], 4.0]'
         assert str(GreaterOperator("report_timestamp",
-                                   datetime.datetime(2016, 06, 11)))\
+                                   datetime.datetime(2016, 6, 11)))\
             == '[">", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_less_operator(self):
@@ -55,7 +55,7 @@ class TestBinaryOperator(object):
         assert str(LessOperator(['parameter', 'version'], 4.0))\
             == '["<", [\'parameter\', \'version\'], 4.0]'
         assert str(LessOperator("report_timestamp",
-                                datetime.datetime(2016, 06, 11)))\
+                                datetime.datetime(2016, 6, 11)))\
             == '["<", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_greater_equal_operator(self):
@@ -68,7 +68,7 @@ class TestBinaryOperator(object):
         assert str(GreaterEqualOperator(['parameter', 'version'], 4.0))\
             == '[">=", [\'parameter\', \'version\'], 4.0]'
         assert str(GreaterEqualOperator("report_timestamp",
-                                        datetime.datetime(2016, 06, 11)))\
+                                        datetime.datetime(2016, 6, 11)))\
             == '[">=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_less_equal_operator(self):
@@ -79,7 +79,7 @@ class TestBinaryOperator(object):
         assert str(LessEqualOperator(['parameter', 'version'], 4.0))\
             == '["<=", [\'parameter\', \'version\'], 4.0]'
         assert str(LessEqualOperator("report_timestamp",
-                                     datetime.datetime(2016, 06, 11)))\
+                                     datetime.datetime(2016, 6, 11)))\
             == '["<=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_regex_operator(self):

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -22,11 +22,13 @@ class TestBinaryOperator(object):
         assert str(EqualsOperator("start_time", "2016-05-11T23:22:48.709Z"))\
             == '["=", "start_time", "2016-05-11T23:22:48.709Z"]'
         assert str(EqualsOperator("is_virtual", True))\
-            == '["=", "is_virtual", True]'
+            == '["=", "is_virtual", true]'
         assert str(EqualsOperator("bios_version", ["6.00", 5.00]))\
             == '["=", "bios_version", [\'6.00\', 5.0]]'
         assert str(EqualsOperator(['parameter', 'ensure'], "present"))\
             == '["=", [\'parameter\', \'ensure\'], "present"]'
+        assert str(EqualsOperator(u"latest_report?", True))\
+            == '["=", "latest_report?", true]'
 
     def test_greater_operator(self):
         assert str(GreaterOperator("uptime", 150))\
@@ -78,9 +80,9 @@ class TestBinaryOperator(object):
 
     def test_null_operator(self):
         assert str(NullOperator("expired", True))\
-            == '["null?", "expired", True]'
+            == '["null?", "expired", true]'
         assert str(NullOperator("report_environment", False))\
-            == '["null?", "report_environment", False]'
+            == '["null?", "report_environment", false]'
         with pytest.raises(APIError):
             NullOperator("environment", "test")
 

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -78,7 +78,7 @@ class TestBinaryOperator(object):
             == '["null?", "expired", True]'
         assert str(NullOperator("report_environment", False))\
             == '["null?", "report_environment", False]'
-        with pytest.raises(ValueError):
+        with pytest.raises(APIError):
             NullOperator("environment", "test")
 
 
@@ -102,7 +102,7 @@ class TestBooleanOperator(object):
             '["=", "architecture", "x86_64"],'\
             '[">", "operatingsystemmajrelease", 6]]'
 
-        with pytest.raises(ValueError):
+        with pytest.raises(APIError):
             op.add({"query1": '["=", "catalog_environment", "production"]'})
 
     def test_or_operator(self):
@@ -121,7 +121,7 @@ class TestBooleanOperator(object):
             '["=", "architecture", "x86_64"],'\
             '[">", "operatingsystemmajrelease", 6]]'
 
-        with pytest.raises(ValueError):
+        with pytest.raises(APIError):
             op.add({"query1": '["=", "catalog_environment", "production"]'})
 
     def test_not_operator(self):
@@ -132,11 +132,41 @@ class TestBooleanOperator(object):
         assert repr(op) == 'Query: ["not",["=", "operatingsystem", "CentOS"]]'
         assert unicode(op) == '["not",["=", "operatingsystem", "CentOS"]]'
 
-        with pytest.raises(ValueError):
+        with pytest.raises(APIError):
             op.add(GreaterOperator("operatingsystemmajrelease", 6))
-        with pytest.raises(ValueError):
+        with pytest.raises(APIError):
             op.add([EqualsOperator("architecture", "x86_64"),
                     GreaterOperator("operatingsystemmajrelease", 6)])
+
+    def test_and_with_no_operations(self):
+        op = AndOperator()
+
+        with pytest.raises(APIError):
+            repr(op)
+        with pytest.raises(APIError):
+            str(op)
+        with pytest.raises(APIError):
+            unicode(op)
+
+    def test_or_with_no_operations(self):
+        op = OrOperator()
+
+        with pytest.raises(APIError):
+            repr(op)
+        with pytest.raises(APIError):
+            str(op)
+        with pytest.raises(APIError):
+            unicode(op)
+
+    def test_not_with_no_operations(self):
+        op = NotOperator()
+
+        with pytest.raises(APIError):
+            repr(op)
+        with pytest.raises(APIError):
+            str(op)
+        with pytest.raises(APIError):
+            unicode(op)
 
 
 class TestExtractOperator(object):

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -1,0 +1,75 @@
+import pytest
+import sys
+
+from pypuppetdb.QueryBuilder import *
+
+
+class TestBinaryOperator(object):
+    """
+    Test the BinaryOperator object and all sub-classes.
+    """
+    def test_equal_operator(self):
+        op = EqualsOperator("certname", "test01")
+        assert str(op) == '["=", "certname", "test01"]'
+        assert repr(op) == 'Query: ["=", "certname", "test01"]'
+        assert unicode(op) == '["=", "certname", "test01"]'
+        assert str(EqualsOperator("clientversion", 91))\
+            == '["=", "clientversion", 91]'
+        assert str(EqualsOperator("start_time", "2016-05-11T23:22:48.709Z"))\
+            == '["=", "start_time", "2016-05-11T23:22:48.709Z"]'
+        assert str(EqualsOperator("is_virtual", True))\
+            == '["=", "is_virtual", True]'
+        assert str(EqualsOperator("bios_version", ["6.00", 5.00]))\
+            == '["=", "bios_version", [\'6.00\', 5.0]]'
+
+    def test_greater_operator(self):
+        assert str(GreaterOperator("uptime", 150))\
+            == '[">", "uptime", 150]'
+        assert str(GreaterOperator("end_time", '"2016-05-11T23:22:48.709Z"'))\
+            == '[">", "end_time", ""2016-05-11T23:22:48.709Z""]'
+
+    def test_less_operator(self):
+        assert str(LessOperator("uptime_seconds", 300))\
+            == '["<", "uptime_seconds", 300]'
+        assert str(LessOperator(
+            "producer_timestamp",
+            "2016-05-11T23:53:29.962Z"))\
+            == '["<", "producer_timestamp", "2016-05-11T23:53:29.962Z"]'
+
+    def test_greater_equal_operator(self):
+        assert str(GreaterEqualOperator("uptime_days", 3))\
+            == '[">=", "uptime_days", 3]'
+        assert str(GreaterEqualOperator(
+            "start_time",
+            "2016-05-11T23:53:29.962Z"))\
+            == '[">=", "start_time", "2016-05-11T23:53:29.962Z"]'
+
+    def test_less_equal_operator(self):
+        assert str(LessEqualOperator("kernelmajversion", 4))\
+            == '["<=", "kernelmajversion", 4]'
+        assert str(LessEqualOperator("end_time", "2016-05-11T23:53:29.962Z"))\
+            == '["<=", "end_time", "2016-05-11T23:53:29.962Z"]'
+
+    def test_regex_operator(self):
+        assert str(RegexOperator("certname", "www\\d+\\.example\\.com"))\
+            == '["~", "certname", "www\\d+\\.example\\.com"]'
+
+    def test_regex_array_operator(self):
+        assert str(RegexArrayOperator(
+            "networking",
+            ["interfaces", "eno.*", "netmask"]))\
+            == '["~>", "networking", [\'interfaces\', \'eno.*\', \'netmask\']]'
+
+    def test_null_operator(self):
+        assert str(NullOperator("expired", True))\
+            == '["null?", "expired", True]'
+        assert str(NullOperator("report_environment", False))\
+            == '["null?", "report_environment", False]'
+        with pytest.raises(ValueError):
+            NullOperator("environment", "test")
+
+
+class TestBooleanOperator(object):
+    """
+    Test the BooleanOperator object and all sub-classes.
+    """

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -147,12 +147,20 @@ class TestExtractOperator(object):
         op = ExtractOperator()
 
         with pytest.raises(pypuppetdb.errors.APIError):
+            repr(op)
+        with pytest.raises(pypuppetdb.errors.APIError):
             str(op)
+        with pytest.raises(pypuppetdb.errors.APIError):
+            unicode(op)
 
         op.add_field("certname")
         op.add_field(['fact_environment', 'catalog_environment'])
 
+        assert repr(op) == 'Query: ["extract",'\
+            '["certname","fact_environment","catalog_environment"]]'
         assert str(op) == '["extract",'\
+            '["certname","fact_environment","catalog_environment"]]'
+        assert unicode(op) == '["extract",'\
             '["certname","fact_environment","catalog_environment"]]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
@@ -168,7 +176,13 @@ class TestExtractOperator(object):
 
         op.add_query(EqualsOperator('domain', 'example.com'))
 
+        assert repr(op) == 'Query: ["extract",'\
+            '["certname","fact_environment","catalog_environment"],'\
+            '["=", "domain", "example.com"]]'
         assert str(op) == '["extract",'\
+            '["certname","fact_environment","catalog_environment"],'\
+            '["=", "domain", "example.com"]]'
+        assert unicode(op) == '["extract",'\
             '["certname","fact_environment","catalog_environment"],'\
             '["=", "domain", "example.com"]]'
 
@@ -185,7 +199,15 @@ class TestExtractOperator(object):
         with pytest.raises(pypuppetdb.errors.APIError):
             op.add_group_by({"deactivated": False})
 
+        assert repr(op) == 'Query: ["extract",'\
+            '["certname","fact_environment","catalog_environment"],'\
+            '["=", "domain", "example.com"],'\
+            '["group_by","fact_environment","catalog_environment"]]'
         assert str(op) == '["extract",'\
+            '["certname","fact_environment","catalog_environment"],'\
+            '["=", "domain", "example.com"],'\
+            '["group_by","fact_environment","catalog_environment"]]'
+        assert unicode(op) == '["extract",'\
             '["certname","fact_environment","catalog_environment"],'\
             '["=", "domain", "example.com"],'\
             '["group_by","fact_environment","catalog_environment"]]'

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 import pypuppetdb
 import sys
@@ -29,6 +30,9 @@ class TestBinaryOperator(object):
             == '["=", [\'parameter\', \'ensure\'], "present"]'
         assert str(EqualsOperator(u"latest_report?", True))\
             == '["=", "latest_report?", true]'
+        assert str(EqualsOperator("report_timestamp",
+                                  datetime.datetime(2016, 06, 11)))\
+            == '["=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_greater_operator(self):
         assert str(GreaterOperator("uptime", 150))\
@@ -37,6 +41,9 @@ class TestBinaryOperator(object):
             == '[">", "end_time", ""2016-05-11T23:22:48.709Z""]'
         assert str(GreaterOperator(['parameter', 'version'], 4.0))\
             == '[">", [\'parameter\', \'version\'], 4.0]'
+        assert str(GreaterOperator("report_timestamp",
+                                   datetime.datetime(2016, 06, 11)))\
+            == '[">", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_less_operator(self):
         assert str(LessOperator("uptime_seconds", 300))\
@@ -47,6 +54,9 @@ class TestBinaryOperator(object):
             == '["<", "producer_timestamp", "2016-05-11T23:53:29.962Z"]'
         assert str(LessOperator(['parameter', 'version'], 4.0))\
             == '["<", [\'parameter\', \'version\'], 4.0]'
+        assert str(LessOperator("report_timestamp",
+                                datetime.datetime(2016, 06, 11)))\
+            == '["<", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_greater_equal_operator(self):
         assert str(GreaterEqualOperator("uptime_days", 3))\
@@ -57,6 +67,9 @@ class TestBinaryOperator(object):
             == '[">=", "start_time", "2016-05-11T23:53:29.962Z"]'
         assert str(GreaterEqualOperator(['parameter', 'version'], 4.0))\
             == '[">=", [\'parameter\', \'version\'], 4.0]'
+        assert str(GreaterEqualOperator("report_timestamp",
+                                        datetime.datetime(2016, 06, 11)))\
+            == '[">=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_less_equal_operator(self):
         assert str(LessEqualOperator("kernelmajversion", 4))\
@@ -65,6 +78,9 @@ class TestBinaryOperator(object):
             == '["<=", "end_time", "2016-05-11T23:53:29.962Z"]'
         assert str(LessEqualOperator(['parameter', 'version'], 4.0))\
             == '["<=", [\'parameter\', \'version\'], 4.0]'
+        assert str(LessEqualOperator("report_timestamp",
+                                     datetime.datetime(2016, 06, 11)))\
+            == '["<=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_regex_operator(self):
         assert str(RegexOperator("certname", "www\\d+\\.example\\.com"))\

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -4,6 +4,8 @@ import sys
 
 from pypuppetdb.QueryBuilder import *
 
+if sys.version_info >= (3, 0):
+    unicode = str
 
 class TestBinaryOperator(object):
     """
@@ -289,11 +291,11 @@ class TestFunctionOperator(object):
             '["function","count","domain"]'
 
     def test_avg_function(self):
-        assert (str(FunctionOperator('avg', 'uptime'))) == \
+        assert str(FunctionOperator('avg', 'uptime')) == \
             '["function","avg","uptime"]'
-        assert (repr(FunctionOperator('avg', 'uptime'))) == \
+        assert repr(FunctionOperator('avg', 'uptime')) == \
             'Query: ["function","avg","uptime"]'
-        assert (unicode(FunctionOperator('avg', 'uptime'))) == \
+        assert unicode(FunctionOperator('avg', 'uptime')) == \
             '["function","avg","uptime"]'
 
         with pytest.raises(pypuppetdb.errors.APIError):

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -7,6 +7,7 @@ from pypuppetdb.QueryBuilder import *
 if sys.version_info >= (3, 0):
     unicode = str
 
+
 class TestBinaryOperator(object):
     """
     Test the BinaryOperator object and all sub-classes.

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -211,3 +211,118 @@ class TestExtractOperator(object):
             '["certname","fact_environment","catalog_environment"],'\
             '["=", "domain", "example.com"],'\
             '["group_by","fact_environment","catalog_environment"]]'
+
+    def test_with_add_function_operator(self):
+        op = ExtractOperator()
+
+        op.add_field(FunctionOperator('to_string',
+                                      'producer_timestamp',
+                                      'FMDAY'))
+        op.add_field(FunctionOperator('count'))
+        op.add_group_by(FunctionOperator('to_string',
+                                         'producer_timestamp',
+                                         'FMDAY'))
+
+        assert str(op) == '["extract",'\
+            '[["function","to_string","producer_timestamp","FMDAY"],'\
+            '["function","count"]],'\
+            '["group_by",'\
+            '["function","to_string","producer_timestamp","FMDAY"]]]'
+        assert repr(op) == 'Query: ["extract",'\
+            '[["function","to_string","producer_timestamp","FMDAY"],'\
+            '["function","count"]],'\
+            '["group_by",'\
+            '["function","to_string","producer_timestamp","FMDAY"]]]'
+        assert unicode(op) == '["extract",'\
+            '[["function","to_string","producer_timestamp","FMDAY"],'\
+            '["function","count"]],'\
+            '["group_by",'\
+            '["function","to_string","producer_timestamp","FMDAY"]]]'
+
+
+class TestFunctionOperator(object):
+    """
+    Test the FunctionOperator object and all sub-classes.
+    """
+    def test_count_function(self):
+        assert str(FunctionOperator('count')) == \
+            '["function","count"]'
+        assert repr(FunctionOperator('count')) == \
+            'Query: ["function","count"]'
+        assert unicode(FunctionOperator('count')) == \
+            '["function","count"]'
+        assert str(FunctionOperator('count', 'domain')) == \
+            '["function","count","domain"]'
+        assert repr(FunctionOperator('count', 'domain')) == \
+            'Query: ["function","count","domain"]'
+        assert unicode(FunctionOperator('count', 'domain')) == \
+            '["function","count","domain"]'
+
+    def test_avg_function(self):
+        assert (str(FunctionOperator('avg', 'uptime'))) == \
+            '["function","avg","uptime"]'
+        assert (repr(FunctionOperator('avg', 'uptime'))) == \
+            'Query: ["function","avg","uptime"]'
+        assert (unicode(FunctionOperator('avg', 'uptime'))) == \
+            '["function","avg","uptime"]'
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("avg")
+
+    def test_sum_function(self):
+        assert str(FunctionOperator('sum', 'memoryfree_mb')) == \
+            '["function","sum","memoryfree_mb"]'
+        assert repr(FunctionOperator('sum', 'memoryfree_mb')) == \
+            'Query: ["function","sum","memoryfree_mb"]'
+        assert unicode(FunctionOperator('sum', 'memoryfree_mb')) == \
+            '["function","sum","memoryfree_mb"]'
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("sum")
+
+    def test_min_function(self):
+        assert str(FunctionOperator('min', 'kernelversion')) == \
+            '["function","min","kernelversion"]'
+        assert repr(FunctionOperator('min', 'kernelversion')) == \
+            'Query: ["function","min","kernelversion"]'
+        assert unicode(FunctionOperator('min', 'kernelversion')) == \
+            '["function","min","kernelversion"]'
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("min")
+
+    def test_max_function(self):
+        assert str(FunctionOperator('max', 'facterversion')) == \
+            '["function","max","facterversion"]'
+        assert repr(FunctionOperator('max', 'facterversion')) == \
+            'Query: ["function","max","facterversion"]'
+        assert unicode(FunctionOperator('max', 'facterversion')) == \
+            '["function","max","facterversion"]'
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("max")
+
+    def test_to_string_function(self):
+        assert str(FunctionOperator("to_string",
+                                    'producer_timestamp',
+                                    'FMDAY')) == \
+            '["function","to_string","producer_timestamp","FMDAY"]'
+        assert repr(FunctionOperator("to_string",
+                                     'producer_timestamp',
+                                     'FMDAY')) == \
+            'Query: ["function","to_string","producer_timestamp","FMDAY"]'
+        assert unicode(FunctionOperator("to_string",
+                                        'producer_timestamp',
+                                        'FMDAY')) == \
+            '["function","to_string","producer_timestamp","FMDAY"]'
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("to_string")
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("to_string", 'receive_time')
+
+    def test_unknown_function(self):
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("std_dev")
+        with pytest.raises(pypuppetdb.errors.APIError):
+            FunctionOperator("last")

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -79,3 +79,27 @@ class TestBinaryOperator(object):
             == '["null?", "report_environment", False]'
         with pytest.raises(ValueError):
             NullOperator("environment", "test")
+
+
+class TestBooleanOperator(object):
+    """
+    Test the BooleanOperator object and all sub-classes.
+    """
+    def test_and_operator(self):
+        op = AndOperator()
+        op.add(EqualsOperator("operatingsystem", "CentOS"))
+        op.add([EqualsOperator("architecture", "x86_64"),
+                GreaterOperator("operatingsystemmajrelease", 6)])
+
+        assert str(op) == '["and",["=", "operatingsystem", "CentOS"],'\
+            '["=", "architecture", "x86_64"],'\
+            '[">", "operatingsystemmajrelease", 6]]'
+        assert repr(op) == 'Query: ["and",["=", "operatingsystem", "CentOS"],'\
+            '["=", "architecture", "x86_64"],'\
+            '[">", "operatingsystemmajrelease", 6]]'
+        assert unicode(op) == '["and",["=", "operatingsystem", "CentOS"],'\
+            '["=", "architecture", "x86_64"],'\
+            '[">", "operatingsystemmajrelease", 6]]'
+
+        with pytest.raises(ValueError):
+            op.add({"query1": '["=", "catalog_environment", "production"]'})


### PR DESCRIPTION
This resolves https://github.com/voxpupuli/pypuppetdb/issues/77

This PR adds a new file QueryBuilder.py which enables the creation of PuppetDB queries in an OOP style where the user can create queries ranging from a single equals query, invoked with `EqualsOperator("certname", "node1.example.com")` to very complex queries with multiple tiers of ands, ors and not queries. All while being able to add more clauses just as easily as adding elements to a list object.