### PR TITLE
pypuppetdb/types.py: Removing the latest_report_noop variable from th…

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -461,8 +461,7 @@ class BaseAPI(object):
                        catalog_environment=node['catalog_environment'],
                        facts_environment=node['facts_environment'],
                        latest_report_hash=node.get('latest_report_hash'),
-                       cached_catalog_status=node.get('cached_catalog_status'),
-                       latest_report_noop=node.get('latest_report_noop')
+                       cached_catalog_status=node.get('cached_catalog_status')
                        )
 
     def node(self, name):

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -348,9 +348,6 @@ class Node(object):
             on this node, possible values are 'explicitly_requested',\
             'on_failure', 'not_used' or None.
     :type cache_catalog_status: :obj:`string`
-    :param latest_report_noop: Determines weather the latest report was\
-            generated with the '--noop' flag.
-    :type latest_report_noop: :obj:`bool`
 
     :ivar name: Hostname of this node.
     :ivar deactivated: :obj:`datetime.datetime` when this host was\
@@ -372,8 +369,6 @@ class Node(object):
             and later.
     :ivar cached_catalog_status: :obj:`string` the status of the cached\
             catalog from the last puppet run.
-    :ivar latest_report_noop: :obj:`bool` the latest report run with the\
-            '--noop' flag.
     """
     def __init__(self, api, name, deactivated=None, expired=None,
                  report_timestamp=None, catalog_timestamp=None,
@@ -381,8 +376,7 @@ class Node(object):
                  unreported_time=None, report_environment='production',
                  catalog_environment='production',
                  facts_environment='production',
-                 latest_report_hash=None, cached_catalog_status=None,
-                 latest_report_noop=None):
+                 latest_report_hash=None, cached_catalog_status=None):
         self.name = name
         self.status = status
         self.events = events
@@ -395,7 +389,6 @@ class Node(object):
         self.facts_environment = facts_environment
         self.latest_report_hash = latest_report_hash
         self.cached_catalog_status = cached_catalog_status
-        self.latest_report_noop = latest_report_noop
 
         if deactivated is not None:
             self.deactivated = json_to_datetime(deactivated)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -115,11 +115,6 @@ class TestNode(object):
         assert node3.name == 'node'
         assert node3.cached_catalog_status == 'not_used'
 
-    def test_with_latest_report_noop(self):
-        node = Node('_', 'node', latest_report_noop=False)
-        assert node.name == 'node'
-        assert not node.latest_report_noop
-
 
 class TestFact(object):
     """Test the Fact object."""


### PR DESCRIPTION
…e Node() type.

This field from PuppetDB is only used to determine the status field.
There's little point in making it its own variable in the type.