### PR TITLE
pypuppetdb/api.py: Fixing last_report calculation bug causing all nod…

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -387,6 +387,7 @@ class BaseAPI(object):
         :rtype: :class:`pypuppetdb.types.Node`
         """
         nodes = self._query('nodes', **kwargs)
+        now = datetime.datetime.utcnow()
         # If we happen to only get one node back it
         # won't be inside a list so iterating over it
         # goes boom. Therefor we wrap a list around it.
@@ -431,8 +432,8 @@ class BaseAPI(object):
                 if node['report_timestamp'] is not None:
                     try:
                         last_report = json_to_datetime(
-                            node['report_timestamp']).replace(tzinfo=None)
-                        now = datetime.utcnow()
+                            node['report_timestamp'])
+                        last_report = last_report.replace(tzinfo=None)
                         unreported_border = now - timedelta(hours=unreported)
                         if last_report < unreported_border:
                             delta = (now - last_report)


### PR DESCRIPTION
…es to report unreported

This fixes #95

One of the intended code cleanups from this release was to combine the
report_timestamp datetime variable into a single line. This bug unintentionally
caused all nodes in the result set to report a status of unreported.

Also caching the `datetime.now()` code to outside the loop, calling it only
once instead of once-per-node.