### PR TITLE
Run Travis tests under newer python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - 3.4
   - 3.5
   - nightly
+matrix:
+  allow_failures:
+    - python: nigthly
 install:
   - pip install -q -r requirements.txt --use-wheel
   - pip install -q coverage coveralls --use-wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - 2.6
   - 2.7
   - 3.3
+  - 3.4
+  - 3.5
+  - nightly
 install:
   - pip install -q -r requirements.txt --use-wheel
   - pip install -q coverage coveralls --use-wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - nightly
-matrix:
-  allow_failures:
-    - python: nigthly
 install:
   - pip install -q -r requirements.txt --use-wheel
   - pip install -q coverage coveralls --use-wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.1.0
-pytest==2.7.0
+pytest==2.7.3
 mock==1.0.1
 git+https://github.com/gabrielfalcao/HTTPretty.git@python-3.3-support#egg=httpretty
 pytest-pep8==1.0.5


### PR DESCRIPTION
I'm looking into running puppetboard under python 3 and want to make sure that pypuppetdb will work on the default python 3.x version on Ubuntu 16.04. Looks good so far :-) 