### PR TITLE
Added support for RBAC token authentication

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,11 @@ def baseapi():
 
 
 @pytest.fixture
+def token_baseapi():
+    return pypuppetdb.api.BaseAPI(token='tokenstring')
+
+
+@pytest.fixture
 def utc():
     """Create a UTC object."""
     return pypuppetdb.utils.UTC()

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -131,3 +131,25 @@ For Debian, install your Puppet Master's certificate in
 
 If you do not wish to do so or for whatever reason want to disable the
 verification of PuppetDB's certificate you can pass in ``ssl_verify=False``.
+
+RBAC Token Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are using Puppet Enterprise Puppetdb >=4.0.2 - an RBAC token can be passed
+to pypuppetdb's ``connect()``:
+
+.. code-block:: python
+
+   >>> db = connect(token='tokenstring')
+
+If this argument is passed, pypuppetdb will automatically switch over to using HTTPS.
+This is handled via the addition of ``X-Authentication`` to the session headers
+
+If you need to disable validation of the certificate PuppetDB is serving, please follow the
+steps documented in the ``Configure pypuppetdb for SSL`` section
+
+It should also be noted that when using RBAC token authentication,
+the ``ssl_key`` and ``ssl_cert`` options should not be used and are not required
+
+If you require more information regarding RBAC token generation in PuppetDB,
+please review Puppet's support documentation. https://docs.puppet.com/pe/latest/rbac_token_auth.html

--- a/pypuppetdb/__init__.py
+++ b/pypuppetdb/__init__.py
@@ -72,7 +72,7 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 def connect(host='localhost', port=8080, ssl_verify=False, ssl_key=None,
             ssl_cert=None, timeout=10, protocol=None, url_path='/',
-            username=None, password=None):
+            username=None, password=None, token=None):
     """Connect with PuppetDB. This will return an object allowing you
     to query the API through its methods.
 
@@ -112,8 +112,11 @@ def connect(host='localhost', port=8080, ssl_verify=False, ssl_key=None,
     :param password: (optional) The password to use for HTTP basic
             authentication
     :type password: :obj:`None` or :obj:`string`
+
+    :param token: (optional) The x-auth token to use for X-Authentication
+    :type token: :obj:`None` or :obj:`string`
     """
     return BaseAPI(host=host, port=port,
                    timeout=timeout, ssl_verify=ssl_verify, ssl_key=ssl_key,
                    ssl_cert=ssl_cert, protocol=protocol, url_path=url_path,
-                   username=username, password=password)
+                   username=username, password=password, token=token)

--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -158,7 +158,7 @@ class BaseAPI(object):
                 'content-type': 'application/json',
                 'accept': 'application/json',
                 'accept-charset': 'utf-8',
-                'X-Authentication': self.token
+                'x-authentication': self.token
             }
         else:
             self.token = None

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -30,6 +30,7 @@ class TestBaseAPIInitOptions(object):
         assert baseapi.ssl_verify is True
         assert baseapi.ssl_key is None
         assert baseapi.ssl_cert is None
+        assert baseapi.token is None
         assert baseapi.timeout == 10
         assert baseapi.protocol == 'http'
         assert baseapi.url_path == ''
@@ -48,6 +49,11 @@ class TestBaseAPIInitOptions(object):
         api = pypuppetdb.api.BaseAPI(ssl_verify=False)
         assert api.ssl_verify is False
         assert api.protocol == 'http'
+
+    def test_token(self):
+        api = pypuppetdb.api.BaseAPI(token='tokenstring')
+        assert api.token == 'tokenstring'
+        assert api.protocol == 'https'
 
     def test_ssl_key(self):
         api = pypuppetdb.api.BaseAPI(ssl_key='/a/b/c.pem')
@@ -178,7 +184,23 @@ class TesteAPIQuery(object):
         with pytest.raises(requests.exceptions.HTTPError):
             baseapi._query('nodes')
 
-    def test_setting_headers(self, baseapi):
+    def test_setting_headers_with_token(self, baseapi):
+        httpretty.enable()
+        stub_request('https://localhost:8080/pdb/query/v4/nodes')
+        baseapi.token = 'tokenstring'
+        baseapi._query('nodes')  # need to query some endpoint
+        request_headers = dict(httpretty.last_request().headers)
+        assert request_headers['Accept'] == 'application/json'
+        assert request_headers['Content-Type'] == 'application/json'
+        assert request_headers['Accept-Charset'] == 'utf-8'
+        assert request_headers['Host'] == 'localhost:8080'
+        assert request_headers['X-Authentication'] == 'tokenstring'
+        assert httpretty.last_request().path == '/pdb/query/v4/nodes'
+        httpretty.disable()
+        httpretty.reset()
+
+    def test_setting_headers_without_token(self, baseapi):
+        api = pypuppetdb.api.BaseAPI(token='tokenstring')
         httpretty.enable()
         stub_request('http://localhost:8080/pdb/query/v4/nodes')
         baseapi._query('nodes')  # need to query some endpoint
@@ -208,7 +230,7 @@ class TesteAPIQuery(object):
         httpretty.disable()
         httpretty.reset()
 
-    def test_with_authorization(self, baseapi):
+    def test_with_password_authorization(self, baseapi):
         httpretty.enable()
         stub_request('http://localhost:8080/pdb/query/v4/nodes')
         baseapi.username = 'puppetdb'
@@ -221,6 +243,15 @@ class TesteAPIQuery(object):
             'Basic {0}'.format(bs_authheader)
         httpretty.disable()
         httpretty.reset()
+
+    def test_with_token_authorization(self, baseapi):
+        httpretty.enable()
+        stub_request('https://localhost:8080/pdb/query/v4/nodes')
+        baseapi.token = 'tokenstring'
+        baseapi._query('nodes')
+        assert httpretty.last_request().path == '/pdb/query/v4/nodes'
+        assert httpretty.last_request().headers['X-Authentication'] == \
+            'tokenstring'
 
     def test_with_query(self, baseapi):
         httpretty.enable()

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -184,11 +184,10 @@ class TesteAPIQuery(object):
         with pytest.raises(requests.exceptions.HTTPError):
             baseapi._query('nodes')
 
-    def test_setting_headers_with_token(self, baseapi):
+    def test_setting_headers_with_token(self, token_baseapi):
         httpretty.enable()
         stub_request('https://localhost:8080/pdb/query/v4/nodes')
-        baseapi.token = 'tokenstring'
-        baseapi._query('nodes')  # need to query some endpoint
+        token_baseapi._query('nodes')  # need to query some endpoint
         request_headers = dict(httpretty.last_request().headers)
         assert request_headers['Accept'] == 'application/json'
         assert request_headers['Content-Type'] == 'application/json'
@@ -200,7 +199,6 @@ class TesteAPIQuery(object):
         httpretty.reset()
 
     def test_setting_headers_without_token(self, baseapi):
-        api = pypuppetdb.api.BaseAPI(token='tokenstring')
         httpretty.enable()
         stub_request('http://localhost:8080/pdb/query/v4/nodes')
         baseapi._query('nodes')  # need to query some endpoint
@@ -244,11 +242,10 @@ class TesteAPIQuery(object):
         httpretty.disable()
         httpretty.reset()
 
-    def test_with_token_authorization(self, baseapi):
+    def test_with_token_authorization(self, token_baseapi):
         httpretty.enable()
         stub_request('https://localhost:8080/pdb/query/v4/nodes')
-        baseapi.token = 'tokenstring'
-        baseapi._query('nodes')
+        token_baseapi._query('nodes')
         assert httpretty.last_request().path == '/pdb/query/v4/nodes'
         assert httpretty.last_request().headers['X-Authentication'] == \
             'tokenstring'


### PR DESCRIPTION
docs/quickstart.rst - added documentation regarding RBAC token
authentication and how this is configured via connect()

pypuppetdb/**init**.py - added additional documentation for rbac token
authenticationa and defined token arg for passing to connect()

pypuppetdb/api.py - added support for RBAC token authentication and
ensured that session headers would contain the X-Authentication object
if a token is passed. Additionally, passing a token will force the
https protocol.

tests/test_baseapi.py - added tests for validating token argument
as well as session header tests and validation of protocols when
a token is passed
