### PR TITLE
puppetdb/api.py: Marking noop runs without events as type unchanged

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -411,7 +411,10 @@ class BaseAPI(object):
 
                 try:
                     if node['latest_report_noop']:
-                        node['status'] = 'noop'
+                        if node['latest_report_status'] == 'unchanged':
+                            node['status'] = 'unchanged'
+                        else:
+                            node['status'] = 'noop'
                     else:
                         node['status'] = node['latest_report_status']
 

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -179,7 +179,7 @@ class Report(object):
         self.run_time = self.end - self.start
         self.transaction = transaction
         self.environment = environment
-        self.status = 'noop' if noop else status
+        self.status = 'noop' if noop and status != 'unchanged' else status
         self.metrics = metrics
         self.logs = logs
         self.code_id = code_id

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -194,7 +194,32 @@ class TestReport(object):
                         '2015-08-31T21:10:00.000Z',
                         '1482347613', 4, '4.2.1',
                         'af9f16e3-75f6-4f90-acc6-f83d6524a6f3',
-                        status='success',
+                        status='unchanged',
+                        noop=True)
+
+        assert report.node == 'node2.puppet.board'
+        assert report.hash_ == 'hash#'
+        assert report.start == json_to_datetime('2015-08-31T21:07:00.000Z')
+        assert report.end == json_to_datetime('2015-08-31T21:09:00.000Z')
+        assert report.received == json_to_datetime('2015-08-31T21:10:00.000Z')
+        assert report.version == '1482347613'
+        assert report.format_ == 4
+        assert report.agent_version == '4.2.1'
+        assert report.run_time == report.end - report.start
+        assert report.transaction == 'af9f16e3-75f6-4f90-acc6-f83d6524a6f3'
+        assert report.status == 'unchanged'
+        assert str(report) == str('hash#')
+        assert unicode(report) == unicode('hash#')
+        assert repr(report) == str('Report: hash#')
+
+    def test_report_with_failed_noop(self):
+        report = Report('_', 'node2.puppet.board', 'hash#',
+                        '2015-08-31T21:07:00.000Z',
+                        '2015-08-31T21:09:00.000Z',
+                        '2015-08-31T21:10:00.000Z',
+                        '1482347613', 4, '4.2.1',
+                        'af9f16e3-75f6-4f90-acc6-f83d6524a6f3',
+                        status='failed',
                         noop=True)
 
         assert report.node == 'node2.puppet.board'


### PR DESCRIPTION
Puppetdb >= 4.1.0 will report status 'unchanged' for noop runs
without events.

Both failures and noops events in noops runs will be reported as
'noop' status.

Resolves #103