### PR TITLE
puppetdb/api.py|types.py: Unreported nodes (#108)

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -402,7 +402,7 @@ class BaseAPI(object):
             )
 
         for node in nodes:
-            node['status'] = None
+            node['status_report'] = None
             node['events'] = None
 
             if with_status:
@@ -410,7 +410,7 @@ class BaseAPI(object):
                           if s['subject']['title'] == node['certname']]
 
                 try:
-                    node['status'] = node['latest_report_status']
+                    node['status_report'] = node['latest_report_status']
 
                     if status:
                         node['events'] = status[0]
@@ -418,13 +418,13 @@ class BaseAPI(object):
                     if status:
                         node['events'] = status = status[0]
                         if status['successes'] > 0:
-                            node['status'] = 'changed'
+                            node['status_report'] = 'changed'
                         if status['noops'] > 0:
-                            node['status'] = 'noop'
+                            node['status_report'] = 'noop'
                         if status['failures'] > 0:
-                            node['status'] = 'failed'
+                            node['status_report'] = 'failed'
                     else:
-                        node['status'] = 'unchanged'
+                        node['status_report'] = 'unchanged'
 
                 # node report age
                 if node['report_timestamp'] is not None:
@@ -435,17 +435,17 @@ class BaseAPI(object):
                         unreported_border = now - timedelta(hours=unreported)
                         if last_report < unreported_border:
                             delta = (now - last_report)
-                            node['status'] = 'unreported'
+                            node['unreported'] = True
                             node['unreported_time'] = '{0}d {1}h {2}m'.format(
                                 delta.days,
                                 int(delta.seconds / 3600),
                                 int((delta.seconds % 3600) / 60)
                             )
                     except AttributeError:
-                        node['status'] = 'unreported'
+                        node['unreported'] = True
 
                 if not node['report_timestamp']:
-                    node['status'] = 'unreported'
+                    node['unreported'] = True
 
             yield Node(self,
                        name=node['certname'],
@@ -454,10 +454,11 @@ class BaseAPI(object):
                        report_timestamp=node['report_timestamp'],
                        catalog_timestamp=node['catalog_timestamp'],
                        facts_timestamp=node['facts_timestamp'],
-                       status=node['status'],
+                       status_report=node['status_report'],
                        noop=node.get('latest_report_noop'),
                        noop_pending=node.get('latest_report_noop_pending'),
                        events=node['events'],
+                       unreported=node.get('unreported'),
                        unreported_time=node.get('unreported_time'),
                        report_environment=node['report_environment'],
                        catalog_environment=node['catalog_environment'],

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -329,8 +329,8 @@ class Node(object):
             collected.
     :type facts_timestamp: :obj:`string` formatted as\
             ``%Y-%m-%dT%H:%M:%S.%fZ``
-    :param status: (default `None`) Status of the node\
-            changed | unchanged | unreported | failed
+    :param status_report: (default `None`) Status of latest report \
+            from the node changed | unchanged | failed
     :type status: :obj:`string`
     :param noop: (Default `False`) A flag indicating whether the latest \
         report of the node was produced by a noop run.
@@ -341,6 +341,8 @@ class Node(object):
     :type noop_pending: :obj:`bool`
     :param events: (default `None`) Counted events from latest Report
     :type events: :obj:`dict`
+    :param unreported: (default `False`) if node is considered unreported
+    :type unreported_time: :obj:`bool`
     :param unreported_time: (default `None`) Time since last report
     :type unreported_time: :obj:`string`
     :param report_environment: (default 'production') The environment of the\
@@ -383,14 +385,14 @@ class Node(object):
     """
     def __init__(self, api, name, deactivated=None, expired=None,
                  report_timestamp=None, catalog_timestamp=None,
-                 facts_timestamp=None, status=None,
+                 facts_timestamp=None, status_report=None,
                  noop=False, noop_pending=False, events=None,
-                 unreported_time=None, report_environment='production',
+                 unreported=False, unreported_time=None,
+                 report_environment='production',
                  catalog_environment='production',
                  facts_environment='production',
                  latest_report_hash=None, cached_catalog_status=None):
         self.name = name
-        self.status = 'noop' if noop and noop_pending else status
         self.events = events
         self.unreported_time = unreported_time
         self.report_timestamp = report_timestamp
@@ -401,6 +403,13 @@ class Node(object):
         self.facts_environment = facts_environment
         self.latest_report_hash = latest_report_hash
         self.cached_catalog_status = cached_catalog_status
+
+        if unreported:
+            self.status = 'unreported'
+        elif noop and noop_pending:
+            self.status = 'noop'
+        else:
+            self.status = status_report
 
         if deactivated is not None:
             self.deactivated = json_to_datetime(deactivated)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -36,7 +36,8 @@ class TestNode(object):
                     report_timestamp='2013-08-01T09:57:00.000Z',
                     catalog_timestamp='2013-08-01T09:57:00.000Z',
                     facts_timestamp='2013-08-01T09:57:00.000Z',
-                    status='unreported',
+                    status_report='unchanged',
+                    unreported=True,
                     unreported_time='0d 5h 20m',)
 
         assert node.name == 'node'
@@ -48,7 +49,55 @@ class TestNode(object):
             json_to_datetime('2013-08-01T09:57:00.000Z')
         assert node.catalog_timestamp == \
             json_to_datetime('2013-08-01T09:57:00.000Z')
-        assert node.status is 'unreported'
+        assert node.status == 'unreported'
+        assert node.unreported_time is '0d 5h 20m'
+        assert str(node) == str('node')
+        assert unicode(node) == unicode('node')
+        assert repr(node) == str('<Node: node>')
+
+    def test_with_status_unreported_from_noop(self):
+        node = Node('_', 'node',
+                    report_timestamp='2013-08-01T09:57:00.000Z',
+                    catalog_timestamp='2013-08-01T09:57:00.000Z',
+                    facts_timestamp='2013-08-01T09:57:00.000Z',
+                    status_report='noop',
+                    unreported=True,
+                    unreported_time='0d 5h 20m',)
+
+        assert node.name == 'node'
+        assert node.deactivated is False
+        assert node.expired is False
+        assert node.report_timestamp == \
+            json_to_datetime('2013-08-01T09:57:00.000Z')
+        assert node.facts_timestamp == \
+            json_to_datetime('2013-08-01T09:57:00.000Z')
+        assert node.catalog_timestamp == \
+            json_to_datetime('2013-08-01T09:57:00.000Z')
+        assert node.status == 'unreported'
+        assert node.unreported_time is '0d 5h 20m'
+        assert str(node) == str('node')
+        assert unicode(node) == unicode('node')
+        assert repr(node) == str('<Node: node>')
+
+    def test_with_status_unreported_from_failed(self):
+        node = Node('_', 'node',
+                    report_timestamp='2013-08-01T09:57:00.000Z',
+                    catalog_timestamp='2013-08-01T09:57:00.000Z',
+                    facts_timestamp='2013-08-01T09:57:00.000Z',
+                    status_report='failed',
+                    unreported=True,
+                    unreported_time='0d 5h 20m',)
+
+        assert node.name == 'node'
+        assert node.deactivated is False
+        assert node.expired is False
+        assert node.report_timestamp == \
+            json_to_datetime('2013-08-01T09:57:00.000Z')
+        assert node.facts_timestamp == \
+            json_to_datetime('2013-08-01T09:57:00.000Z')
+        assert node.catalog_timestamp == \
+            json_to_datetime('2013-08-01T09:57:00.000Z')
+        assert node.status == 'unreported'
         assert node.unreported_time is '0d 5h 20m'
         assert str(node) == str('node')
         assert unicode(node) == unicode('node')
@@ -56,7 +105,7 @@ class TestNode(object):
 
     def test_apiv4_with_failed_status(self):
         node = Node('_', 'node',
-                    status='failed',
+                    status_report='failed',
                     report_environment='development',
                     catalog_environment='development',
                     facts_environment='development',
@@ -84,7 +133,7 @@ class TestNode(object):
 
     def test_apiv4_with_unchanged_status(self):
         node = Node('_', 'node',
-                    status='unchanged',
+                    status_report='unchanged',
                     report_environment='development',
                     catalog_environment='development',
                     facts_environment='development',
@@ -112,7 +161,7 @@ class TestNode(object):
 
     def test_apiv4_with_unchanged_noop_status(self):
         node = Node('_', 'node',
-                    status='unchanged',
+                    status_report='unchanged',
                     noop=True,
                     noop_pending=False,
                     report_environment='development',
@@ -142,7 +191,7 @@ class TestNode(object):
 
     def test_apiv4_with_pending_noop_status(self):
         node = Node('_', 'node',
-                    status='unchanged',
+                    status_report='unchanged',
                     noop=True,
                     noop_pending=True,
                     report_environment='development',
@@ -172,7 +221,7 @@ class TestNode(object):
 
     def test_apiv4_with_failed_noop_status(self):
         node = Node('_', 'node',
-                    status='failed',
+                    status_report='failed',
                     noop=True,
                     noop_pending=False,
                     report_environment='development',


### PR DESCRIPTION
If a node has a 'noop' status and go unreported, it was reporting it as 'noop' instead of 'unreported'.

That doesn't happen for puppetdb < 4.1x, nor to other status (unchanged, failed or changed).

I assume that creating the `Node` object is not considered a valid API use, and that this change would be considered non-breaking change because the api.py is still called the same way and return the same object. 

This problem doesn't happen in report, because it doesn't have a concept of 'unreported'. 
