### PR TITLE
Add subquery and in operators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,14 +200,32 @@ belonging to the production environment.
    >>> op = AndOperator()
    >>> op.add(EqualsOperator('catalog_environment', 'production'))
    >>> op.add(EqualsOperator('facts_environment', 'production'))
-   >>> echo op
-   '["and",["=", "catalog_environment", "production"],["=", "facts_environment", "production"]]'
+   >>> print(op)
+   ["and",["=", "catalog_environment", "production"],["=", "facts_environment", "production"]]
 
 This functionality is based on the PuppetDB AST query string syntax documented
-`here`_. However, we do not yet support subqueries. That is planned in a future
-release.
+`here`_.
 
 .. _here: https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html
+
+Subqueries are implemented using corresponding operators (like documented).
+
+* SubqueryOperator
+* InOperator
+* ExtractOperator
+
+.. code-block:: python
+
+   >>> from pypuppetdb.QueryBuilder import *
+   >>> op = InOperator('certname')
+   >>> ex = ExtractOperator()
+   >>> ex.add_field(str('certname'))
+   >>> sub = SubqueryOperator('events')
+   >>> sub.add_query(EqualsOperator('status', 'noop'))
+   >>> ex.add_query(sub)
+   >>> op.add_query(ex)
+   >>> print(op)
+   ["in","certname",["extract",["certname"],["select_events",["=", "status", "noop"]]]]
 
 Getting Help
 ============

--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -92,10 +92,11 @@ class BooleanOperator(object):
             for i in query:
                 self.add(i)
         elif (type(query) == str or
-                isinstance(query, (BinaryOperator, BooleanOperator))):
+                isinstance(query, (BinaryOperator, InOperator,
+                                   BooleanOperator))):
             self.operations.append(str(query))
         else:
-            raise APIError("Can only accpet fixed-string queries, arrays " +
+            raise APIError("Can only accept fixed-string queries, arrays " +
                            "or operator objects")
 
     def __repr__(self):

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -384,3 +384,51 @@ class TestFunctionOperator(object):
             FunctionOperator("std_dev")
         with pytest.raises(pypuppetdb.errors.APIError):
             FunctionOperator("last")
+
+
+class TestSubqueryOperator(object):
+    """
+    Test the SubqueryOperator object
+    """
+    def test_events_endpoint(self):
+        assert str(SubqueryOperator('events')) == \
+            '["select_events"]'
+
+        op = SubqueryOperator('events')
+        op.add_query(EqualsOperator('status', 'noop'))
+
+        assert repr(op) == 'Query: ["select_events",'\
+            '["=", "status", "noop"]]'
+
+    def test_multiple_add_query(self):
+        with pytest.raises(pypuppetdb.errors.APIError):
+            op = SubqueryOperator('events')
+            op.add_query(EqualsOperator('status', 'noop'))
+            op.add_query(EqualsOperator('status', 'changed'))
+
+    def test_unknown_endpoint(self):
+        with pytest.raises(pypuppetdb.errors.APIError):
+            SubqueryOperator('cats')
+
+
+class TestInOperator(object):
+    """
+    Test the InOperator object
+    """
+    def test_events_endpoint(self):
+        assert str(InOperator('certname')) == \
+            '["in","certname"]'
+
+        op = InOperator('certname')
+        ex = ExtractOperator()
+        ex.add_field("certname")
+        op.add_query(ex)
+
+        assert repr(op) == 'Query: ["in","certname",' \
+            '["extract",["certname"]]]'
+
+    def test_multiple_add_query(self):
+        with pytest.raises(pypuppetdb.errors.APIError):
+            op = InOperator('certname')
+            op.add_query(ExtractOperator())
+            op.add_query(ExtractOperator())


### PR DESCRIPTION

Working on puppetboard, I needed some operators documented here 
https://docs.puppet.com/puppetdb/3.2/api/query/v4/operators.html#subquery-operators

List of endpoints authorized for the Subquery operator come from 3.2. 3.0 miss some of them, but available ones may still be usable.

Client example code -
`
    events_query = AndOperator()
    events_query.add(EqualsOperator('status', 'noop'))
    log.error(events_query)
    subquery = SubqueryOperator('events')
    subquery.add_query(events_query)
    log.error(subquery)
    extract_query = ExtractOperator()
    extract_query.add_field(str('certname'))
    extract_query.add_query(subquery)
    log.error(extract_query)
    in_query = InOperator("certname")
    in_query.add_query(extract_query)
    log.error(in_query)
    r = get_or_abort(
        puppetdb.reports,
        query=in_query,
        order_by=order_args,
        include_total=True,
        **paging_args)
`

Tried to respect coding standards.