### PR TITLE
fix pytest section in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts = --cov=pypuppetdb --cov-report=term-missing
 norecursedirs = docs .tox
 minversion = 2.3


### PR DESCRIPTION
without this I get:
warning : [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.

during: py.test --help
This PR fixes it. Tested on python 3.6