### PR TITLE
Fix bug with parsing results from inventory endpoint

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -847,9 +847,9 @@ class BaseAPI(object):
         inventory = self._query('inventory', **kwargs)
         for inv in inventory:
             yield Inventory(
-                node=inv.certname,
-                time=inv.timestamp,
-                environment=inv.environment,
-                facts=inv.facts,
-                trusted=inv.trusted
+                node=inv['certname'],
+                time=inv['timestamp'],
+                environment=inv['environment'],
+                facts=inv['facts'],
+                trusted=inv['trusted']
             )

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -362,6 +362,27 @@ class TestAPIMethods(object):
         httpretty.disable()
         httpretty.reset()
 
+    def test_facts(self, baseapi):
+        facts_body = [{
+            'certname': 'test_certname',
+            'name': 'test_name',
+            'value': 'test_value',
+            'environment': 'test_environment',
+        }]
+        facts_url = 'http://localhost:8080/pdb/query/v4/facts'
+
+        httpretty.enable()
+        httpretty.register_uri(httpretty.GET, facts_url,
+                               body=json.dumps(facts_body))
+
+        for fact in baseapi.facts():
+            pass
+
+        assert httpretty.last_request().path == '/pdb/query/v4/facts'
+
+        httpretty.disable()
+        httpretty.reset()
+
     def test_fact_names(self, baseapi):
         httpretty.enable()
         stub_request('http://localhost:8080/pdb/query/v4/fact-names')
@@ -380,5 +401,26 @@ class TestAPIMethods(object):
         stub_request('http://localhost:8080/pdb/query/v4/environments')
         baseapi.environments()
         assert httpretty.last_request().path == '/pdb/query/v4/environments'
+        httpretty.disable()
+        httpretty.reset()
+
+    def test_inventory(self, baseapi):
+        inventory_body = [{
+            'certname': 'test_certname',
+            'timestamp': '2017-07-13T18:39:53.895118579+00:00',
+            'environment': 'test_environment',
+            'facts': 'test_facts',
+            'trusted': 'test_trusted'
+        }]
+        inventory_url = 'http://localhost:8080/pdb/query/v4/inventory'
+
+        httpretty.enable()
+        httpretty.register_uri(httpretty.GET, inventory_url,
+                               body=json.dumps(inventory_body))
+        for inv in baseapi.inventory():
+            pass
+
+        assert httpretty.last_request().path == '/pdb/query/v4/inventory'
+
         httpretty.disable()
         httpretty.reset()

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -407,7 +407,7 @@ class TestAPIMethods(object):
     def test_inventory(self, baseapi):
         inventory_body = [{
             'certname': 'test_certname',
-            'timestamp': '2017-07-13T18:39:53.895118579+00:00',
+            'timestamp': '2017-06-05T20:18:23.374Z',
             'environment': 'test_environment',
             'facts': 'test_facts',
             'trusted': 'test_trusted'


### PR DESCRIPTION
* :bug: Fix a bug that prevented us from parsing results using dot-operator on the inventory endpoint

```
    def inventory(self, **kwargs):
        """Get Node and Fact information with an alternative query syntax
            for structured facts instead of using the facts, fact-contents and
            factsets endpoints for many fact-related queries.
    
            :param \*\*kwargs: The rest of the keyword arguments are passed
                               to the _query function.
    
            :returns: A generator yielding Inventory
            :rtype: :class:`pypuppetdb.types.Inventory`
            """
        inventory = self._query('inventory', **kwargs)
        for inv in inventory:
            yield Inventory(
>               node=inv.certname,
                time=inv.timestamp,
                environment=inv.environment,
                facts=inv.facts,
                trusted=inv.trusted
            )
E           AttributeError: 'dict' object has no attribute 'certname'
```
Also, these all use dictionary notation for parsing the json response:
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L466-L483
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L554-L559
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L629-L639
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L671-L678
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L695-L710
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L814-L834

And it would appear that this one missed the cut:
https://github.com/voxpupuli/pypuppetdb/blob/62f4b61/pypuppetdb/api.py#L849-L855