### PR TITLE
version bumps in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 bandit
 cov-core==1.15.0
-coverage==4.0
+coverage==4.4.2
 git+https://github.com/gabrielfalcao/HTTPretty.git@python-3.3-support#egg=httpretty
-mock==1.0.1
-pytest==3.0.1
-pytest-cov==2.2.1
-pytest-pep8==1.0.5
+mock==2.0.0
+pytest==3.2.5
+pytest-cov==2.5.1
+pytest-pep8==1.0.6
 requests==2.1.0


### PR DESCRIPTION
A warning from py.test inspired me to update versions of upstream dependencies in requirements.txt.
Specifically the old version of pytest-cov was using a deprecated py.test api call causing py.test to warn.