### PR TITLE
Adding new endpoint: status

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -46,6 +46,7 @@ ENDPOINTS = {
     'edges': 'pdb/query/v4/edges',
     'pql': 'pdb/query/v4',
     'inventory': 'pdb/query/v4/inventory',
+    'status': 'status/v1/services/puppetdb-status',
 }
 
 PARAMETERS = {
@@ -853,3 +854,11 @@ class BaseAPI(object):
                 facts=inv['facts'],
                 trusted=inv['trusted']
             )
+
+    def status(self):
+        """Get PuppetDB server status.
+
+        :returns: A dict with the PuppetDB status information
+        :rtype: :obj:`dict`
+        """
+        return self._query('status')

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -424,3 +424,14 @@ class TestAPIMethods(object):
 
         httpretty.disable()
         httpretty.reset()
+
+    def test_status(self, baseapi):
+        httpretty.enable()
+        stub_request(
+            'http://localhost:8080/status/v1/services/puppetdb-status'
+            )
+        baseapi.status()
+        assert httpretty.last_request().path == \
+            '/status/v1/services/puppetdb-status'
+        httpretty.disable()
+        httpretty.reset()


### PR DESCRIPTION
The PuppetDB status endpoint returns a dictionary with status information
about the PuppetDB server.

https://puppet.com/docs/puppetdb/5.2/api/status/v1/status.html