### PR TITLE
Send POST queries in body of request

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -261,7 +261,7 @@ class BaseAPI(object):
     def _query(self, endpoint, path=None, query=None,
                order_by=None, limit=None, offset=None, include_total=False,
                summarize_by=None, count_by=None, count_filter=None,
-               post_as_body=False, request_method='GET'):
+               request_method='GET'):
         """This method actually querries PuppetDB. Provided an endpoint and an
         optional path and/or query it will fire a request at PuppetDB. If
         PuppetDB can be reached and answers within the timeout we'll decode
@@ -294,9 +294,6 @@ class BaseAPI(object):
         :type count_by: :obj:`string`
         :param count_filter: (optional) Specify a filter for the results
         :type count_filter: :obj:`string`
-        :param post_as_body: (optional) With POST, send query as the body of\
-                the request instead of in the query string
-        :type post_as_body: :obj:`bool`
 
         :raises: :class:`~pypuppetdb.errors.EmptyResponseError`
 
@@ -346,18 +343,12 @@ class BaseAPI(object):
                                       timeout=self.timeout,
                                       auth=auth)
             elif request_method.upper() == 'POST':
-                if post_as_body:
-                    # JSON encode payload and stick it in the body of the POST
-                    query_payload = {'data': json.dumps(payload, default=str)}
-                else:
-                    # form-encode the payload in the query string
-                    query_payload = {'params': payload}
                 r = self._session.post(url,
+                                       data=json.dumps(payload, default=str),
                                        verify=self.ssl_verify,
                                        cert=(self.ssl_cert, self.ssl_key),
                                        timeout=self.timeout,
-                                       auth=auth,
-                                       **query_payload)
+                                       auth=auth)
             else:
                 log.error("Only GET or POST supported, {0} unsupported".format(
                           request_method))

--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -313,9 +313,6 @@ class BaseAPI(object):
 
         payload = {}
         if query is not None:
-            if request_method == 'POST' and post_as_body:
-                # make QueryBuilder query work for JSON encoding
-                query = str(query)
             payload['query'] = query
         if order_by is not None:
             payload[PARAMETERS['order_by']] = order_by
@@ -351,7 +348,7 @@ class BaseAPI(object):
             elif request_method.upper() == 'POST':
                 if post_as_body:
                     # JSON encode payload and stick it in the body of the POST
-                    query_payload = {'data': json.dumps(payload)}
+                    query_payload = {'data': json.dumps(payload, default=str)}
                 else:
                     # form-encode the payload in the query string
                     query_payload = {'params': payload}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest==3.0.1
 pytest-cov==2.2.1
 pytest-pep8==1.0.5
 requests==2.1.0
+six==1.11.0

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -382,7 +382,8 @@ class TesteAPIQuery(object):
         assert last_request.querystring == {}
         assert last_request.headers['Content-Type'] == 'application/json'
         assert last_request.method == 'POST'
-        assert last_request.body == six.b(json.dumps({'query': query, 'count_by': 1}))
+        assert last_request.body == six.b(json.dumps({'query': query,
+                                                      'count_by': 1}))
         httpretty.disable()
         httpretty.reset()
 

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -352,6 +352,20 @@ class TesteAPIQuery(object):
         httpretty.disable()
         httpretty.reset()
 
+    def test_query_with_post(self, baseapi):
+        httpretty.reset()
+        httpretty.enable()
+        stub_request('http://localhost:8080/pdb/query/v4/nodes',
+                     method=httpretty.POST)
+        baseapi._query('nodes',
+                       query='["certname", "=", "node1"]',
+                       request_method='POST')
+        assert httpretty.last_request().querystring == {
+            'query': ['["certname", "=", "node1"]']}
+        assert httpretty.last_request().method == httpretty.POST
+        httpretty.disable()
+        httpretty.reset()
+
 
 class TestAPIMethods(object):
     def test_metric(self, baseapi):

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -366,6 +366,25 @@ class TesteAPIQuery(object):
         httpretty.disable()
         httpretty.reset()
 
+    def test_query_with_post_body(self, baseapi):
+        httpretty.reset()
+        httpretty.enable()
+        query = '["certname", "=", "node1"]'
+        stub_request('http://localhost:8080/pdb/query/v4/nodes',
+                     method=httpretty.POST)
+        baseapi._query('nodes',
+                       query=query,
+                       count_by=1,
+                       request_method='POST',
+                       post_as_body=True)
+        last_request = httpretty.last_request()
+        assert last_request.querystring == {}
+        assert last_request.headers['Content-Type'] == 'application/json'
+        assert last_request.method == httpretty.POST
+        assert last_request.body == json.dumps({'query': query, 'count_by': 1})
+        httpretty.disable()
+        httpretty.reset()
+
 
 class TestAPIMethods(object):
     def test_metric(self, baseapi):

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -370,23 +370,8 @@ class TesteAPIQuery(object):
                      method=httpretty.POST)
         baseapi._query('nodes',
                        query=query,
-                       request_method='POST')
-        assert httpretty.last_request().querystring == {
-            'query': [str(query)]}
-        assert httpretty.last_request().method == 'POST'
-        httpretty.disable()
-        httpretty.reset()
-
-    def test_query_with_post_body(self, baseapi, query):
-        httpretty.reset()
-        httpretty.enable()
-        stub_request('http://localhost:8080/pdb/query/v4/nodes',
-                     method=httpretty.POST)
-        baseapi._query('nodes',
-                       query=query,
                        count_by=1,
-                       request_method='POST',
-                       post_as_body=True)
+                       request_method='POST')
         last_request = httpretty.last_request()
         assert last_request.querystring == {}
         assert last_request.headers['Content-Type'] == 'application/json'

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -5,6 +5,7 @@ import httpretty
 import pytest
 import requests
 import pypuppetdb
+import six
 
 
 def stub_request(url, data=None, method=httpretty.GET, status=200, **kwargs):
@@ -362,7 +363,7 @@ class TesteAPIQuery(object):
                        request_method='POST')
         assert httpretty.last_request().querystring == {
             'query': ['["certname", "=", "node1"]']}
-        assert httpretty.last_request().method == httpretty.POST
+        assert httpretty.last_request().method == 'POST'
         httpretty.disable()
         httpretty.reset()
 
@@ -380,8 +381,8 @@ class TesteAPIQuery(object):
         last_request = httpretty.last_request()
         assert last_request.querystring == {}
         assert last_request.headers['Content-Type'] == 'application/json'
-        assert last_request.method == httpretty.POST
-        assert last_request.body == json.dumps({'query': query, 'count_by': 1})
+        assert last_request.method == 'POST'
+        assert last_request.body == six.b(json.dumps({'query': query, 'count_by': 1}))
         httpretty.disable()
         httpretty.reset()
 

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -7,13 +7,13 @@ import requests
 import pypuppetdb
 
 
-def stub_request(url, data=None, **kwargs):
+def stub_request(url, data=None, method=httpretty.GET, status=200, **kwargs):
     if data is None:
         body = '[]'
     else:
         with open(data, 'r') as d:
             body = json.load(d.read())
-    return httpretty.register_uri(httpretty.GET, url, body=body, status=200,
+    return httpretty.register_uri(method, url, body=body, status=status,
                                   **kwargs)
 
 


### PR DESCRIPTION
PuppetDB will ignore query and filter specifications if the request is sent using POST and the query is sent in the querystring of the URI. Sending a POST request to PuppetDB with a query requires sending it in the body of the request.

This is not specifically documented that we have found, but is implied by the examples on the puppetdb documentation. It has been empirically tested, and our testing has shown this to be the case.

As an example, take a request to puppetdb for a specific node:

 ```
db.nodes(query='["=", "certname", "vm1.broker.dev"]')
```

If this request is sent as a POST, but not specifying that the query should be in the body, then the request will form encode the query in the URI, and PuppetDB will return the list of all nodes, rather than the specific node.

If this request is sent as a POST, and we specify the query should be in the body, then the PuppetDB will return only the node that matches the certname.

In order to send a POST request with the query in the body, `requests` requires that the parameters be JSON encoded and the JSON data passed as the `data` parameter to the `post()` method.

This closes issue #132 