### PR TITLE
QueryBuilder: Added support for arrays with InOperator

### DIFF
--- a/pypuppetdb/QueryBuilder.py
+++ b/pypuppetdb/QueryBuilder.py
@@ -318,6 +318,17 @@ class InOperator(object):
                            "strings and ExtractOperator"
                            "objects")
 
+    def add_array(self, values):
+        if self.query is not None:
+            raise APIError("Only one array is supported by the InOperator")
+        elif values[0] == "array" and isinstance(values[1], list):
+            self.query = True
+            self.arr.append(str(values))
+        else:
+            raise APIErrfor("InOperator.add_array: Ill-formatted array, "
+                           "must be of the format: "
+                           "['array', [<array values>]]")
+
     def __repr__(self):
         return str('Query: [{0}]'.format(",".join(self.arr)))
 
@@ -326,7 +337,6 @@ class InOperator(object):
 
     def __unicode__(self):
         return str('[{0}]'.format(",".join(self.arr)))
-
 
 class EqualsOperator(BinaryOperator):
     """

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -458,3 +458,11 @@ class TestInOperator(object):
             op = InOperator('certname') 
             op.test_add_arry(arr)
             op.test_add_arry(arr)
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            op = InOperator('certname')
+
+            op.test_add_arry(arr)
+            ex = ExtractOperator()
+            ex.add_field("certname")
+            op.add_query(ex) 

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -432,3 +432,29 @@ class TestInOperator(object):
             op = InOperator('certname')
             op.add_query(ExtractOperator())
             op.add_query(ExtractOperator())
+
+    def test_add_arry(self):
+        arr = ['array', [1, 2, 3]]
+        op = InOperator('certname') 
+        op.test_add_arry(arr)
+
+        assert repr(op) == 'Query: ["in","certname",' \
+            '["extract",[1, 2, 3]]]'
+
+    def test_invalid_add_array(self):
+        arr = ['array', [1, 2, 3]]
+        inv1 = ['arrayfoo', [1, 2, 3]]
+        inv2 = ['arrayfoo', [1, 2, 3], 'bar']
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            op = InOperator('certname') 
+            op.test_add_arry(inv1)
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            op = InOperator('certname') 
+            op.test_add_arry(inv2)
+
+        with pytest.raises(pypuppetdb.errors.APIError):
+            op = InOperator('certname') 
+            op.test_add_arry(arr)
+            op.test_add_arry(arr)


### PR DESCRIPTION
Support for Arrays with InOperator as per: https://docs.puppet.com/puppetdb/4.1/api/query/v4/ast.html#subquery-operators. Additionally, added two functions for unit testing (both of which pass).