### PR TITLE
Base return types for generator errors

### DIFF
--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -461,7 +461,7 @@ class Node(object):
     def fact(self, name):
         """Get a single fact from this node."""
         facts = self.facts(name=name)
-        return next(fact for fact in facts)
+        return next((fact for fact in facts), None)
 
     def resources(self, type_=None, title=None, **kwargs):
         """Get all resources of this node or all resources of the specified
@@ -495,7 +495,7 @@ class Node(object):
             title=title,
             query=EqualsOperator("certname", self.name),
             **kwargs)
-        return next(resource for resource in resources)
+        return next((resource for resource in resources), None)
 
     def reports(self, **kwargs):
         """Get all reports for this node. Additional arguments may also be

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -461,7 +461,7 @@ class Node(object):
     def fact(self, name):
         """Get a single fact from this node."""
         facts = self.facts(name=name)
-        return next((fact for fact in facts), None)
+        return next((fact for fact in facts), [])
 
     def resources(self, type_=None, title=None, **kwargs):
         """Get all resources of this node or all resources of the specified
@@ -495,7 +495,7 @@ class Node(object):
             title=title,
             query=EqualsOperator("certname", self.name),
             **kwargs)
-        return next((resource for resource in resources), None)
+        return next((resource for resource in resources), [])
 
     def reports(self, **kwargs):
         """Get all reports for this node. Additional arguments may also be


### PR DESCRIPTION
There are a couple methods in the puppetdb API which return empty lists instead of 404s when querying an invalid value, two of these being queries for a particular fact name of a node (/pdb/query/v4/nodes/<NODE>/facts/<NAME>), or a resource type/name (/pdb/query/v4/resources/<TYPE>/<TITLE>)

In the types objects for pypuppetdb, these two queries used a return next(x for x in y) type pattern, however since the API returns an empty list, the implied generator starts out empty, and instead of returning a valid object, raises a StopIteration, which is not handled by pypuppetdb.

For the end user, this is extremely confusing, as a StopIteration doesn't behave like a standard exception. I've added in a default case to the next() method to return the empty list in case of an invalid result, which mimics the behavior of the puppetdb API.

While I have managed to manually test these changes against my own puppet infrastructure, there doesn't seem to be an easy way for me to add unit tests for the changes given the current pytest fixtures available, as the Node.fact() method relies on the underlying baseapi.