### PR TITLE
QueryBuilder.py: Use native data structures for internal representation

### DIFF
--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -25,9 +25,9 @@ class TestBinaryOperator(object):
         assert str(EqualsOperator("is_virtual", True))\
             == '["=", "is_virtual", true]'
         assert str(EqualsOperator("bios_version", ["6.00", 5.00]))\
-            == '["=", "bios_version", [\'6.00\', 5.0]]'
+            == '["=", "bios_version", ["6.00", 5.0]]'
         assert str(EqualsOperator(['parameter', 'ensure'], "present"))\
-            == '["=", [\'parameter\', \'ensure\'], "present"]'
+            == '["=", ["parameter", "ensure"], "present"]'
         assert str(EqualsOperator(u"latest_report?", True))\
             == '["=", "latest_report?", true]'
         assert str(EqualsOperator("report_timestamp",
@@ -37,10 +37,10 @@ class TestBinaryOperator(object):
     def test_greater_operator(self):
         assert str(GreaterOperator("uptime", 150))\
             == '[">", "uptime", 150]'
-        assert str(GreaterOperator("end_time", '"2016-05-11T23:22:48.709Z"'))\
-            == '[">", "end_time", ""2016-05-11T23:22:48.709Z""]'
+        assert str(GreaterOperator("end_time", '2016-05-11T23:22:48.709Z'))\
+            == '[">", "end_time", "2016-05-11T23:22:48.709Z"]'
         assert str(GreaterOperator(['parameter', 'version'], 4.0))\
-            == '[">", [\'parameter\', \'version\'], 4.0]'
+            == '[">", ["parameter", "version"], 4.0]'
         assert str(GreaterOperator("report_timestamp",
                                    datetime.datetime(2016, 6, 11)))\
             == '[">", "report_timestamp", "2016-06-11 00:00:00"]'
@@ -53,7 +53,7 @@ class TestBinaryOperator(object):
             "2016-05-11T23:53:29.962Z"))\
             == '["<", "producer_timestamp", "2016-05-11T23:53:29.962Z"]'
         assert str(LessOperator(['parameter', 'version'], 4.0))\
-            == '["<", [\'parameter\', \'version\'], 4.0]'
+            == '["<", ["parameter", "version"], 4.0]'
         assert str(LessOperator("report_timestamp",
                                 datetime.datetime(2016, 6, 11)))\
             == '["<", "report_timestamp", "2016-06-11 00:00:00"]'
@@ -66,7 +66,7 @@ class TestBinaryOperator(object):
             "2016-05-11T23:53:29.962Z"))\
             == '[">=", "start_time", "2016-05-11T23:53:29.962Z"]'
         assert str(GreaterEqualOperator(['parameter', 'version'], 4.0))\
-            == '[">=", [\'parameter\', \'version\'], 4.0]'
+            == '[">=", ["parameter", "version"], 4.0]'
         assert str(GreaterEqualOperator("report_timestamp",
                                         datetime.datetime(2016, 6, 11)))\
             == '[">=", "report_timestamp", "2016-06-11 00:00:00"]'
@@ -77,22 +77,22 @@ class TestBinaryOperator(object):
         assert str(LessEqualOperator("end_time", "2016-05-11T23:53:29.962Z"))\
             == '["<=", "end_time", "2016-05-11T23:53:29.962Z"]'
         assert str(LessEqualOperator(['parameter', 'version'], 4.0))\
-            == '["<=", [\'parameter\', \'version\'], 4.0]'
+            == '["<=", ["parameter", "version"], 4.0]'
         assert str(LessEqualOperator("report_timestamp",
                                      datetime.datetime(2016, 6, 11)))\
             == '["<=", "report_timestamp", "2016-06-11 00:00:00"]'
 
     def test_regex_operator(self):
         assert str(RegexOperator("certname", "www\\d+\\.example\\.com"))\
-            == '["~", "certname", "www\\d+\\.example\\.com"]'
+            == '["~", "certname", "www\\\\d+\\\\.example\\\\.com"]'
         assert str(RegexOperator(['parameter', 'version'], "4\\.\\d+"))\
-            == '["~", [\'parameter\', \'version\'], "4\\.\\d+"]'
+            == '["~", ["parameter", "version"], "4\\\\.\\\\d+"]'
 
     def test_regex_array_operator(self):
         assert str(RegexArrayOperator(
             "networking",
             ["interfaces", "eno.*", "netmask"]))\
-            == '["~>", "networking", [\'interfaces\', \'eno.*\', \'netmask\']]'
+            == '["~>", "networking", ["interfaces", "eno.*", "netmask"]]'
 
     def test_null_operator(self):
         assert str(NullOperator("expired", True))\
@@ -113,14 +113,15 @@ class TestBooleanOperator(object):
         op.add([EqualsOperator("architecture", "x86_64"),
                 GreaterOperator("operatingsystemmajrelease", 6)])
 
-        assert str(op) == '["and",["=", "operatingsystem", "CentOS"],'\
-            '["=", "architecture", "x86_64"],'\
+        assert str(op) == '["and", ["=", "operatingsystem", "CentOS"], '\
+            '["=", "architecture", "x86_64"], '\
             '[">", "operatingsystemmajrelease", 6]]'
-        assert repr(op) == 'Query: ["and",["=", "operatingsystem", "CentOS"],'\
-            '["=", "architecture", "x86_64"],'\
+        assert repr(op) == 'Query: ["and", '\
+            '["=", "operatingsystem", "CentOS"], '\
+            '["=", "architecture", "x86_64"], '\
             '[">", "operatingsystemmajrelease", 6]]'
-        assert unicode(op) == '["and",["=", "operatingsystem", "CentOS"],'\
-            '["=", "architecture", "x86_64"],'\
+        assert unicode(op) == '["and", ["=", "operatingsystem", "CentOS"], '\
+            '["=", "architecture", "x86_64"], '\
             '[">", "operatingsystemmajrelease", 6]]'
 
         with pytest.raises(APIError):
@@ -132,14 +133,15 @@ class TestBooleanOperator(object):
         op.add([EqualsOperator("architecture", "x86_64"),
                 GreaterOperator("operatingsystemmajrelease", 6)])
 
-        assert str(op) == '["or",["=", "operatingsystem", "CentOS"],'\
-            '["=", "architecture", "x86_64"],'\
+        assert str(op) == '["or", ["=", "operatingsystem", "CentOS"], '\
+            '["=", "architecture", "x86_64"], '\
             '[">", "operatingsystemmajrelease", 6]]'
-        assert repr(op) == 'Query: ["or",["=", "operatingsystem", "CentOS"],'\
-            '["=", "architecture", "x86_64"],'\
+        assert repr(op) == 'Query: ["or", '\
+            '["=", "operatingsystem", "CentOS"], '\
+            '["=", "architecture", "x86_64"], '\
             '[">", "operatingsystemmajrelease", 6]]'
-        assert unicode(op) == '["or",["=", "operatingsystem", "CentOS"],'\
-            '["=", "architecture", "x86_64"],'\
+        assert unicode(op) == '["or", ["=", "operatingsystem", "CentOS"], '\
+            '["=", "architecture", "x86_64"], '\
             '[">", "operatingsystemmajrelease", 6]]'
 
         with pytest.raises(APIError):
@@ -149,9 +151,9 @@ class TestBooleanOperator(object):
         op = NotOperator()
         op.add(EqualsOperator("operatingsystem", "CentOS"))
 
-        assert str(op) == '["not",["=", "operatingsystem", "CentOS"]]'
-        assert repr(op) == 'Query: ["not",["=", "operatingsystem", "CentOS"]]'
-        assert unicode(op) == '["not",["=", "operatingsystem", "CentOS"]]'
+        assert str(op) == '["not", ["=", "operatingsystem", "CentOS"]]'
+        assert repr(op) == 'Query: ["not", ["=", "operatingsystem", "CentOS"]]'
+        assert unicode(op) == '["not", ["=", "operatingsystem", "CentOS"]]'
 
         with pytest.raises(APIError):
             op.add(GreaterOperator("operatingsystemmajrelease", 6))
@@ -214,12 +216,12 @@ class TestExtractOperator(object):
         op.add_field("certname")
         op.add_field(['fact_environment', 'catalog_environment'])
 
-        assert repr(op) == 'Query: ["extract",'\
-            '["certname","fact_environment","catalog_environment"]]'
-        assert str(op) == '["extract",'\
-            '["certname","fact_environment","catalog_environment"]]'
-        assert unicode(op) == '["extract",'\
-            '["certname","fact_environment","catalog_environment"]]'
+        assert repr(op) == 'Query: ["extract", '\
+            '["certname", "fact_environment", "catalog_environment"]]'
+        assert str(op) == '["extract", '\
+            '["certname", "fact_environment", "catalog_environment"]]'
+        assert unicode(op) == '["extract", '\
+            '["certname", "fact_environment", "catalog_environment"]]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             op.add_field({'equal': 'operatingsystemrelease'})
@@ -234,14 +236,14 @@ class TestExtractOperator(object):
 
         op.add_query(EqualsOperator('domain', 'example.com'))
 
-        assert repr(op) == 'Query: ["extract",'\
-            '["certname","fact_environment","catalog_environment"],'\
+        assert repr(op) == 'Query: ["extract", '\
+            '["certname", "fact_environment", "catalog_environment"], '\
             '["=", "domain", "example.com"]]'
-        assert str(op) == '["extract",'\
-            '["certname","fact_environment","catalog_environment"],'\
+        assert str(op) == '["extract", '\
+            '["certname", "fact_environment", "catalog_environment"], '\
             '["=", "domain", "example.com"]]'
-        assert unicode(op) == '["extract",'\
-            '["certname","fact_environment","catalog_environment"],'\
+        assert unicode(op) == '["extract", '\
+            '["certname", "fact_environment", "catalog_environment"], '\
             '["=", "domain", "example.com"]]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
@@ -257,18 +259,18 @@ class TestExtractOperator(object):
         with pytest.raises(pypuppetdb.errors.APIError):
             op.add_group_by({"deactivated": False})
 
-        assert repr(op) == 'Query: ["extract",'\
-            '["certname","fact_environment","catalog_environment"],'\
-            '["=", "domain", "example.com"],'\
-            '["group_by","fact_environment","catalog_environment"]]'
-        assert str(op) == '["extract",'\
-            '["certname","fact_environment","catalog_environment"],'\
-            '["=", "domain", "example.com"],'\
-            '["group_by","fact_environment","catalog_environment"]]'
-        assert unicode(op) == '["extract",'\
-            '["certname","fact_environment","catalog_environment"],'\
-            '["=", "domain", "example.com"],'\
-            '["group_by","fact_environment","catalog_environment"]]'
+        assert repr(op) == 'Query: ["extract", '\
+            '["certname", "fact_environment", "catalog_environment"], '\
+            '["=", "domain", "example.com"], '\
+            '["group_by", "fact_environment", "catalog_environment"]]'
+        assert str(op) == '["extract", '\
+            '["certname", "fact_environment", "catalog_environment"], '\
+            '["=", "domain", "example.com"], '\
+            '["group_by", "fact_environment", "catalog_environment"]]'
+        assert unicode(op) == '["extract", '\
+            '["certname", "fact_environment", "catalog_environment"], '\
+            '["=", "domain", "example.com"], '\
+            '["group_by", "fact_environment", "catalog_environment"]]'
 
     def test_with_add_function_operator(self):
         op = ExtractOperator()
@@ -281,21 +283,21 @@ class TestExtractOperator(object):
                                          'producer_timestamp',
                                          'FMDAY'))
 
-        assert str(op) == '["extract",'\
-            '[["function","to_string","producer_timestamp","FMDAY"],'\
-            '["function","count"]],'\
-            '["group_by",'\
-            '["function","to_string","producer_timestamp","FMDAY"]]]'
-        assert repr(op) == 'Query: ["extract",'\
-            '[["function","to_string","producer_timestamp","FMDAY"],'\
-            '["function","count"]],'\
-            '["group_by",'\
-            '["function","to_string","producer_timestamp","FMDAY"]]]'
-        assert unicode(op) == '["extract",'\
-            '[["function","to_string","producer_timestamp","FMDAY"],'\
-            '["function","count"]],'\
-            '["group_by",'\
-            '["function","to_string","producer_timestamp","FMDAY"]]]'
+        assert str(op) == '["extract", '\
+            '[["function", "to_string", "producer_timestamp", "FMDAY"], '\
+            '["function", "count"]], '\
+            '["group_by", '\
+            '["function", "to_string", "producer_timestamp", "FMDAY"]]]'
+        assert repr(op) == 'Query: ["extract", '\
+            '[["function", "to_string", "producer_timestamp", "FMDAY"], '\
+            '["function", "count"]], '\
+            '["group_by", '\
+            '["function", "to_string", "producer_timestamp", "FMDAY"]]]'
+        assert unicode(op) == '["extract", '\
+            '[["function", "to_string", "producer_timestamp", "FMDAY"], '\
+            '["function", "count"]], '\
+            '["group_by", '\
+            '["function", "to_string", "producer_timestamp", "FMDAY"]]]'
 
 
 class TestFunctionOperator(object):
@@ -304,58 +306,58 @@ class TestFunctionOperator(object):
     """
     def test_count_function(self):
         assert str(FunctionOperator('count')) == \
-            '["function","count"]'
+            '["function", "count"]'
         assert repr(FunctionOperator('count')) == \
-            'Query: ["function","count"]'
+            'Query: ["function", "count"]'
         assert unicode(FunctionOperator('count')) == \
-            '["function","count"]'
+            '["function", "count"]'
         assert str(FunctionOperator('count', 'domain')) == \
-            '["function","count","domain"]'
+            '["function", "count", "domain"]'
         assert repr(FunctionOperator('count', 'domain')) == \
-            'Query: ["function","count","domain"]'
+            'Query: ["function", "count", "domain"]'
         assert unicode(FunctionOperator('count', 'domain')) == \
-            '["function","count","domain"]'
+            '["function", "count", "domain"]'
 
     def test_avg_function(self):
         assert str(FunctionOperator('avg', 'uptime')) == \
-            '["function","avg","uptime"]'
+            '["function", "avg", "uptime"]'
         assert repr(FunctionOperator('avg', 'uptime')) == \
-            'Query: ["function","avg","uptime"]'
+            'Query: ["function", "avg", "uptime"]'
         assert unicode(FunctionOperator('avg', 'uptime')) == \
-            '["function","avg","uptime"]'
+            '["function", "avg", "uptime"]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             FunctionOperator("avg")
 
     def test_sum_function(self):
         assert str(FunctionOperator('sum', 'memoryfree_mb')) == \
-            '["function","sum","memoryfree_mb"]'
+            '["function", "sum", "memoryfree_mb"]'
         assert repr(FunctionOperator('sum', 'memoryfree_mb')) == \
-            'Query: ["function","sum","memoryfree_mb"]'
+            'Query: ["function", "sum", "memoryfree_mb"]'
         assert unicode(FunctionOperator('sum', 'memoryfree_mb')) == \
-            '["function","sum","memoryfree_mb"]'
+            '["function", "sum", "memoryfree_mb"]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             FunctionOperator("sum")
 
     def test_min_function(self):
         assert str(FunctionOperator('min', 'kernelversion')) == \
-            '["function","min","kernelversion"]'
+            '["function", "min", "kernelversion"]'
         assert repr(FunctionOperator('min', 'kernelversion')) == \
-            'Query: ["function","min","kernelversion"]'
+            'Query: ["function", "min", "kernelversion"]'
         assert unicode(FunctionOperator('min', 'kernelversion')) == \
-            '["function","min","kernelversion"]'
+            '["function", "min", "kernelversion"]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             FunctionOperator("min")
 
     def test_max_function(self):
         assert str(FunctionOperator('max', 'facterversion')) == \
-            '["function","max","facterversion"]'
+            '["function", "max", "facterversion"]'
         assert repr(FunctionOperator('max', 'facterversion')) == \
-            'Query: ["function","max","facterversion"]'
+            'Query: ["function", "max", "facterversion"]'
         assert unicode(FunctionOperator('max', 'facterversion')) == \
-            '["function","max","facterversion"]'
+            '["function", "max", "facterversion"]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             FunctionOperator("max")
@@ -364,15 +366,15 @@ class TestFunctionOperator(object):
         assert str(FunctionOperator("to_string",
                                     'producer_timestamp',
                                     'FMDAY')) == \
-            '["function","to_string","producer_timestamp","FMDAY"]'
+            '["function", "to_string", "producer_timestamp", "FMDAY"]'
         assert repr(FunctionOperator("to_string",
                                      'producer_timestamp',
                                      'FMDAY')) == \
-            'Query: ["function","to_string","producer_timestamp","FMDAY"]'
+            'Query: ["function", "to_string", "producer_timestamp", "FMDAY"]'
         assert unicode(FunctionOperator("to_string",
                                         'producer_timestamp',
                                         'FMDAY')) == \
-            '["function","to_string","producer_timestamp","FMDAY"]'
+            '["function", "to_string", "producer_timestamp", "FMDAY"]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             FunctionOperator("to_string")
@@ -397,7 +399,7 @@ class TestSubqueryOperator(object):
         op = SubqueryOperator('events')
         op.add_query(EqualsOperator('status', 'noop'))
 
-        assert repr(op) == 'Query: ["select_events",'\
+        assert repr(op) == 'Query: ["select_events", '\
             '["=", "status", "noop"]]'
 
     def test_multiple_add_query(self):
@@ -417,15 +419,15 @@ class TestInOperator(object):
     """
     def test_events_endpoint(self):
         assert str(InOperator('certname')) == \
-            '["in","certname"]'
+            '["in", "certname"]'
 
         op = InOperator('certname')
         ex = ExtractOperator()
         ex.add_field("certname")
         op.add_query(ex)
 
-        assert repr(op) == 'Query: ["in","certname",' \
-            '["extract",["certname"]]]'
+        assert repr(op) == 'Query: ["in", "certname", ' \
+            '["extract", ["certname"]]]'
 
     def test_multiple_add_query(self):
         with pytest.raises(pypuppetdb.errors.APIError):
@@ -438,7 +440,7 @@ class TestInOperator(object):
         op = InOperator('certname')
         op.add_array(arr)
 
-        assert repr(op) == 'Query: ["in","certname",' \
+        assert repr(op) == 'Query: ["in", "certname", ' \
             '["array", [1, "2", 3]]]'
 
     def test_invalid_add_array(self):
@@ -476,9 +478,9 @@ class TestInOperator(object):
         fr.add_offset(10)
         op.add_query(fr)
 
-        assert repr(op) == 'Query: ["in","certname",' \
-            '["from","facts",["extract",' \
-            '["certname","facts"]],["offset", 10]]]'
+        assert repr(op) == 'Query: ["in", "certname", ' \
+            '["from", "facts", ["extract", ' \
+            '["certname", "facts"]], ["offset", 10]]]'
 
         # last example on page
         # https://puppet.com/docs/puppetdb/5.1/api/query/v4/ast.html
@@ -495,10 +497,10 @@ class TestInOperator(object):
         fr.add_query(ex)
         op.add_query(fr)
 
-        assert unicode(op) == '["in","certname",' \
-            '["from","fact_contents",' \
-            '["extract",["certname"],["and",["=", "path", ' \
-            '["networking", "eth0", "macaddresses", 0]],' \
+        assert unicode(op) == '["in", "certname", ' \
+            '["from", "fact_contents", ' \
+            '["extract", ["certname"], ["and", ["=", "path", ' \
+            '["networking", "eth0", "macaddresses", 0]], ' \
             '["=", "value", "aa:bb:cc:dd:ee:00"]]]]]'
 
 
@@ -521,7 +523,7 @@ class TestFromOperator(object):
         op = EqualsOperator("certname", "test01")
         fr.add_query(op)
 
-        assert str(fr) == '["from","facts",["=", "certname", "test01"]]'
+        assert str(fr) == '["from", "facts", ["=", "certname", "test01"]]'
 
         fr2 = FromOperator("facts")
         op2 = "test, test, test"
@@ -537,8 +539,8 @@ class TestFromOperator(object):
         fr3.add_query(op3)
 
         assert str(fr3) == \
-            '["from","facts",["extract",'\
-            '["certname","fact_environment","catalog_environment"]]]'
+            '["from", "facts", ["extract", '\
+            '["certname", "fact_environment", "catalog_environment"]]]'
 
     def test_limit_offset(self):
         fr = FromOperator("facts")
@@ -547,21 +549,21 @@ class TestFromOperator(object):
 
         fr.add_offset(10)
         assert str(fr) == \
-            '["from","facts",["=", "certname", "test01"],["offset", 10]]'
+            '["from", "facts", ["=", "certname", "test01"], ["offset", 10]]'
 
         fr.add_limit(5)
         assert str(fr) == \
-            '["from","facts",["=", "certname",' \
-            ' "test01"],["limit", 5],["offset", 10]]'
+            '["from", "facts", ["=", "certname",' \
+            ' "test01"], ["limit", 5], ["offset", 10]]'
 
         fr.add_limit(15)
         assert unicode(fr) == \
-            '["from","facts",["=", "certname",' \
-            ' "test01"],["limit", 15],["offset", 10]]'
+            '["from", "facts", ["=", "certname",' \
+            ' "test01"], ["limit", 15], ["offset", 10]]'
 
         assert repr(fr) == \
-            'Query: ["from","facts",["=", "certname",' \
-            ' "test01"],["limit", 15],["offset", 10]]'
+            'Query: ["from", "facts", ["=", "certname",' \
+            ' "test01"], ["limit", 15], ["offset", 10]]'
 
         with pytest.raises(pypuppetdb.errors.APIError):
             fr.add_offset("invalid")
@@ -580,25 +582,25 @@ class TestFromOperator(object):
 
         fr.add_order_by(o1)
         assert str(fr) == \
-            '["from","facts",["=", "certname", ' \
-            '"test01"],["order_by", ["certname"]]]'
+            '["from", "facts", ["=", "certname", ' \
+            '"test01"], ["order_by", ["certname"]]]'
 
         fr.add_order_by(o2)
         assert repr(fr) == \
-            'Query: ["from","facts",' \
-            '["=", "certname", "test01"],' \
+            'Query: ["from", "facts", ' \
+            '["=", "certname", "test01"], ' \
             '["order_by", ["certname", ' \
             '["timestamp", "desc"], "facts"]]]'
 
         assert str(fr) == \
-            '["from","facts",' \
-            '["=", "certname", "test01"],' \
+            '["from", "facts", ' \
+            '["=", "certname", "test01"], ' \
             '["order_by", ["certname", ' \
             '["timestamp", "desc"], "facts"]]]'
 
         assert unicode(fr) == \
-            '["from","facts",' \
-            '["=", "certname", "test01"],' \
+            '["from", "facts", ' \
+            '["=", "certname", "test01"], ' \
             '["order_by", ["certname", ' \
             '["timestamp", "desc"], "facts"]]]'
 


### PR DESCRIPTION
The [PuppetDB documentation][1] says that queries are JSON arrays, so
this commit updates all of the QueryBuilder classes to use lists/dicts
for the internal representation and defers the JSON serialization until
the `str()` call. This avoids having to manually quote things or do
string manipulation. `obj.json_data()` will return the native data
structure and `str(obj)` will return the serialized JSON.

Most of the changes to the tests are just fixing whitespace, but there
are a few places where duplicated quotes and backslash escaping were
fixed.

[1]: https://puppet.com/docs/puppetdb/5.1/api/query/v4/facts.html#url-parameters

Fixes: #140

Signed-off-by: Andrew Gunnerson <andrew.gunnerson@us.ibm.com>