### PR TITLE
Httpretty is not used outside tests and breaks install on newer python versions for some systems

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ filterwarnings =
 markers =
     pep8: workaround for https://bitbucket.org/pytest-dev/pytest-pep8/issues/23/
 pep8maxlinelength = 100
+addopts = --cov=pypuppetdb --cov-report=term-missing
+norecursedirs = docs .tox venv .eggs lib
+python_files = tests/*.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,3 +11,4 @@ pytest-mock==1.11.2
 pytest-mypy==0.4.2
 cov-core==1.15.0
 mypy==0.740
+httpretty==0.9.7

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,14 +1,14 @@
 -r requirements.txt
 coveralls
 bandit
-coverage==4.5.4
-pep8==1.7.1
-mock==3.0.5
-pytest==5.2.2
-pytest-cov==2.8.1
-pytest-pep8==1.0.6
-pytest-mock==1.11.2
-pytest-mypy==0.4.2
-cov-core==1.15.0
-mypy==0.740
-httpretty==0.9.7
+coverage
+pep8
+mock
+pytest
+pytest-cov
+pytest-pep8
+pytest-mock
+pytest-mypy
+cov-core
+mypy
+httpretty

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-httpretty==0.9.7
 requests==2.22.0
 six==1.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,18 +11,13 @@ cover-package = pypuppetdb
 [flake8]
 exclude=venv
 
-[tool:pytest]
-addopts = --cov=pypuppetdb --cov-report=term-missing
-norecursedirs = docs .tox venv .eggs lib
-python_files = tests/*.py
-
 [mypy]
 python_version = 3.8
 ignore_missing_imports=True
 ignore_errors=False
 pretty=True
 
-[mypy-setup,puppetboard.docker_settings]
+[mypy-setup]
 ignore_errors = True
 
 [bdist_wheel]


### PR DESCRIPTION
This resolves [Puppetboard issue 536](https://github.com/voxpupuli/puppetboard/issues/536)

In addition fixing coveralls, moving pytest configuration to single file and stopping pinning test packages.