### PR TITLE
Python 2.x code support is breaking modules

### DIFF
--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -5,8 +5,10 @@ import hashlib
 import json
 import logging
 from datetime import datetime, timedelta
-from urllib.parse import quote
-
+try:
+    from urllib import quote  # Python 2.X
+except ImportError:
+    from urllib.parse import quote  # Python 3+
 import requests
 
 from pypuppetdb.QueryBuilder import (EqualsOperator)


### PR DESCRIPTION
Hi, We use the Puppetboard project on our Puppet Masters. Recent removal of Python 2.x support from here has broken the modules. 

Could we not have have code like the suggested change above which should support both Python 2 and 3?

Either way, the above is required to ensure https://github.com/voxpupuli/puppetboard still works. I'm not sure if Voxpupuli should be withdrawing support for Python 2 from code until all supported modules or dependencies are ready for the change.