### PR TITLE
Metrics v2 fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 #########
 
+Development
+===========
+* Bugfix: Fixed `metric()` function to query the new v2 endpoint based on Jolokia (https://jolokia.org/reference/html/protocol.html)
+* Added new `metrics()` function that returns a metrics listing. This was needed to support the metrics v2 endpoint.
+* Added new `payload` parameter to `_query()` to allow users to send arbitrary payloads with their queries (useful for debugging).
+
+
 2.0.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,13 @@ Changelog
 Development
 ===========
 * Bugfix: Fixed `metric()` function to query the new v2 endpoint based on Jolokia (https://jolokia.org/reference/html/protocol.html)
-* Added new `metrics()` function that returns a metrics listing. This was needed to support the metrics v2 endpoint.
+* Added a new parameter `metric_api_version` to the `BaseAPI()` constructor that allows
+  changing the version of the `metric` API being queried. Valid values are `'v1'` for
+  PuppetDB <= 6.9.0, `'v2'` for PuppetDB >= 6.9.1 or `None` which defaults to `'v2'`.
+* Added a mew parameter `version` to the `metric()` function that allows overriding the version
+  of the metric API being queried for that individual call. If nothing is specified it will
+  default to the `self.metric_api_version` of the class, else it expects a value of `'v1'` or
+  `'v2'` same as the `metric_api_version` class parameter.
 * Added new `payload` parameter to `_query()` to allow users to send arbitrary payloads with their queries (useful for debugging).
 
 


### PR DESCRIPTION
Several fixes / improvements here:

- With the new metrics v2 endpoint, special characters needed to be escaped out in order to properly pass them in the URL.
- Added a new `metrics()` function that returns a metrics list and fixed `metric()` when passed no parameters to return that list. In metrics v2 these the "list" and "read" are two different endpoints.
- Added all available metrics endpoints based on the Jolokia documentation: https://jolokia.org/reference/html/protocol.html
- Added a `payload` parameter to `_query()` so that people can pass arbitrary payloads during debugging (was helpful for me when figuring all of this stuff out with metrics escaping problems).