### PR TITLE
Loosen requirements and drop six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests==2.22.0
-six==1.13.0
+requests>=2.22.0


### PR DESCRIPTION
We do not need strictly pinned version of requests, the package works also with newer versions.

six is not used anywhere in the package.