### PR TITLE
Enable with statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,14 @@ The first thing you need to do is to connect with PuppetDB:
    >>> from pypuppetdb import connect
    >>> db = connect()
 
+Once you're all done with requests to PuppetDB, you can explicitly close all
+HTTP connections. This can be useful if you made those connections through a
+tunnel, which might be tracking open connections:
+
+.. code-block:: python
+
+   >>> db.disconnect()
+
 You can also use the `with` statement to enclose the work done on PuppetDB.
 This will ensure that all HTTP connections are closed explicitly when we're
 done:

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,15 @@ The first thing you need to do is to connect with PuppetDB:
    >>> from pypuppetdb import connect
    >>> db = connect()
 
+You can also use the `with` statement to enclose the work done on PuppetDB.
+This will ensure that all HTTP connections are closed explicitly when we're
+done:
+
+.. code-block:: python
+
+   >>> with connect() as db:
+   >>>   # ..
+
 Nodes
 -----
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,6 +15,15 @@ The first thing you need to do is to connect with PuppetDB:
    >>> from pypuppetdb import connect
    >>> db = connect()
 
+You can also use the `with` statement to enclose the work done on PuppetDB.
+This will ensure that all HTTP connections are closed explicitly when we're
+done:
+
+.. code-block:: python
+
+   >>> with connect() as db:
+   >>>   # ..
+
 Nodes
 -----
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,6 +15,14 @@ The first thing you need to do is to connect with PuppetDB:
    >>> from pypuppetdb import connect
    >>> db = connect()
 
+Once you're all done with requests to PuppetDB, you can explicitly close all
+HTTP connections. This can be useful if you made those connections through a
+tunnel, which might be tracking open connections:
+
+.. code-block:: python
+
+   >>> db.disconnect()
+
 You can also use the `with` statement to enclose the work done on PuppetDB.
 This will ensure that all HTTP connections are closed explicitly when we're
 done:

--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -194,6 +194,14 @@ class BaseAPI(object):
         else:
             self.protocol = 'http'
 
+    def disconnect(self):
+        """Close all connections that this class opened up."""
+        # If we don't explicitly close connections, we might cause other
+        # functions or libraries to hang on the open connections. This happens
+        # for example with using paramiko to tunnel PuppetDB connections
+        # through ssh.
+        self._session.close()
+
     def __enter__(self):
         """Set up environment for 'with' statement."""
         # Once this class has been instantiated, there's nothing more required
@@ -201,11 +209,7 @@ class BaseAPI(object):
 
     def __exit__(self, type, value, trace):
         """Tear down connections."""
-        # If we don't explicitly close connections, we might cause other
-        # functions or libraries to hang on the open connections. This happens
-        # for example with using paramiko to tunnel PuppetDB connections
-        # through ssh.
-        self._session.close()
+        self.disconnect()
 
     @property
     def version(self):

--- a/pypuppetdb/api.py
+++ b/pypuppetdb/api.py
@@ -194,6 +194,19 @@ class BaseAPI(object):
         else:
             self.protocol = 'http'
 
+    def __enter__(self):
+        """Set up environment for 'with' statement."""
+        # Once this class has been instantiated, there's nothing more required
+        return self
+
+    def __exit__(self, type, value, trace):
+        """Tear down connections."""
+        # If we don't explicitly close connections, we might cause other
+        # functions or libraries to hang on the open connections. This happens
+        # for example with using paramiko to tunnel PuppetDB connections
+        # through ssh.
+        self._session.close()
+
     @property
     def version(self):
         """The version of the API we're querying against.

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -3,9 +3,13 @@ import mock
 import pypuppetdb
 
 
-def test_connect_api():
+@mock.patch('pypuppetdb.api.requests.Session.close')
+def test_connect_api(session_close):
     puppetdb = pypuppetdb.connect()
     assert puppetdb.version == 'v4'
+
+    puppetdb.disconnect()
+    assert session_close.called
 
 
 @mock.patch('pypuppetdb.api.requests.Session.close')

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -4,3 +4,8 @@ import pypuppetdb
 def test_connect_api():
     puppetdb = pypuppetdb.connect()
     assert puppetdb.version == 'v4'
+
+
+def test_connect_with_statement():
+    with pypuppetdb.connect() as puppetdb:
+        assert puppetdb.version == 'v4'

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,3 +1,5 @@
+import mock
+
 import pypuppetdb
 
 
@@ -6,6 +8,9 @@ def test_connect_api():
     assert puppetdb.version == 'v4'
 
 
-def test_connect_with_statement():
+@mock.patch('pypuppetdb.api.requests.Session.close')
+def test_connect_with_statement(session_close):
     with pypuppetdb.connect() as puppetdb:
         assert puppetdb.version == 'v4'
+
+    assert session_close.called


### PR DESCRIPTION
WIth this change it becomes possible to enclose puppetdb calls inside a "with" block so that all HTTP connections get explicitely closed when we're done.

I've had to explicitly close connections when working with paramiko for tunneling puppetdb requests through ssh.