### PR TITLE
setup.py requires presence of other files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ You can install this package from source or from PyPi.
 .. code-block:: bash
 
    $ git clone https://github.com/voxpupuli/pypuppetdb
+   $ cd pypuppetdb
    $ python setup.py install
 
 If you wish to hack on it clone the repository but after that run:


### PR DESCRIPTION
Without cd, python complains can't open setup.py; if trying to run pypuppetdb/setup.py, it complains No such file or directory: 'README.rst'