### PR TITLE
Fix generating docs for Readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+---
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs/requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,11 @@ Documentation will automatically be rebuilt on every push thanks to the
 Read The Docs webhook. You can [find it
 here](https://pypuppetdb.readthedocs.org/en/latest/).
 
-You can build the documentation manually by doing:
+You can build the documentation locally by doing:
 
 ```bash
-# Activate the virtualenv and install sphinx + the theme we are using
-pip install sphinx sphinx-rtd-theme
+# Activate the virtualenv used for the app development
+pip install -r docs/requirements.txt
 cd docs
 make html
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -528,8 +528,6 @@ class Catalog(object):
         corresponding report
     :ivar edges: :obj:`list` of :obj:`Edge` The source Resource object\
         of the relationship
-    :ivar resources: :obj:`dict` of :class:`pypuppetdb.types.Resource` The\
-        source Resource object of the relationship
     :ivar environment: :obj:`string` Environment associated with the
         catalog's certname
     :ivar code_id: :obj:`string` ties the catalog to the Puppet code that\
@@ -608,7 +606,7 @@ class Edge(object):
     :type source: :class:`pypuppetdb.Resource`
     :param target: The target Resource object of the relationship
     :type target: :class:`pypuppetdb.Resource`
-    :param relaptionship: Name of the Puppet Ressource Relationship
+    :param relationship: Name of the Puppet Resource Relationship
     :type relationship: :obj:`string`
     :param node: The certname of the node that owns this Relationship
     :type node: :obj:`string`


### PR DESCRIPTION
* We need to use Python 3 as we need to install pypuppetdb to get its code
  parsed for autodoc
* Warnings in doc build mean that autodocs failed - this is critical,
  as docs will be incomplete, so break such build
* Fix a warning from doc build
* Update info how to build the docs locally