### PR TITLE
Make rtd docs versioned

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: publish 🐍 to PyPI
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   build-n-publish:
@@ -26,7 +26,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.1
         with:
           password: ${{ secrets.PYPI_API_TOKEN_PYPUPPETDB }}
-          # repository_url: https://test.pypi.org/legacy/
       - name: Create release in GitHub
         id: create_release
         uses: actions/create-release@v1
@@ -34,6 +33,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: v${{ github.ref }}
           draft: false
           prerelease: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,11 @@ pip install --upgrade -r docs/requirements.txt
 cd docs
 make html
 ```
+
+## Preparing a release
+
+This project is using [tbump](https://github.com/dmerejkowsky/tbump) for releases.
+
+1. Add entry to the `CHANGELOG.md` / verify that it contains all the changes.
+2. Run `tbump <new_version>`
+3. Edit the release created in GitHub - if needed correct the type (final/prerelease), update the description with a changelog fragment.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,27 @@
+# Uncomment this if your project is hosted on GitHub:
+github_url = "https://github.com/voxpupuli/pypuppetdb/"
+
+[version]
+current = "2.5.1"
+
+# Example of a semver regexp.
+# Make sure this matches current_version before
+# using tbump
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (.*)
+  '''
+
+[git]
+message_template = "Release v{new_version}"
+tag_template = "{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "version"


### PR DESCRIPTION
thanks to a change in the release process:
use tags without the "v" prefix for releases.

To make it easier to remember document the
process and introduce a tool for it - tbump.

Note that we keep the "v" prefix in the
GitHub releases as there is no need
to change this.