### PR TITLE
Fix documentation files referenced in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include README.rst
-include CHANGELOG.rst
+include README.md
+include CHANGELOG.md
 include LICENSE
 include requirements.txt
 include version


### PR DESCRIPTION
With PR #190 documentation files were renamed (`.rst` to `.md`).